### PR TITLE
IBX-1466: Switched to \Ibexa\Contracts\Core\Ibexa::VERSION

### DIFF
--- a/src/bundle/DependencyInjection/IbexaSystemInfoExtension.php
+++ b/src/bundle/DependencyInjection/IbexaSystemInfoExtension.php
@@ -8,9 +8,9 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\SystemInfo\DependencyInjection;
 
-use EzSystems\EzPlatformCoreBundle\EzPlatformCoreBundle;
 use Ibexa\Bundle\SystemInfo\SystemInfo\Collector\IbexaSystemInfoCollector;
 use Ibexa\Bundle\SystemInfo\SystemInfo\Value\IbexaSystemInfo;
+use Ibexa\Contracts\Core\Ibexa;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -71,9 +71,9 @@ class IbexaSystemInfoExtension extends Extension implements PrependExtensionInte
         $name = self::getNameByPackages($vendor);
 
         if ($release === 'major') {
-            $name .= ' v' . (int)EzPlatformCoreBundle::VERSION;
+            $name .= ' v' . (int)Ibexa::VERSION;
         } elseif ($release === 'minor') {
-            $version = explode('.', EzPlatformCoreBundle::VERSION);
+            $version = explode('.', Ibexa::VERSION);
             $name .= ' v' . $version[0] . '.' . $version[1];
         }
 

--- a/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
@@ -6,7 +6,7 @@
  */
 namespace Ibexa\Bundle\SystemInfo\SystemInfo\Collector;
 
-use EzSystems\EzPlatformCoreBundle\EzPlatformCoreBundle;
+use Ibexa\Contracts\Core\Ibexa;
 use Ibexa\SystemInfo\Value\Stability;
 use Ibexa\Bundle\SystemInfo\DependencyInjection\IbexaSystemInfoExtension;
 use Ibexa\Bundle\SystemInfo\SystemInfo\Exception\ComposerFileValidationException;
@@ -171,7 +171,7 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
      */
     private function setReleaseInfo(IbexaSystemInfo $ibexa): void
     {
-        $ibexa->release = EzPlatformCoreBundle::VERSION;
+        $ibexa->release = Ibexa::VERSION;
         // try to extract version number, but prepare for unexpected string
         [$majorVersion, $minorVersion] = array_pad(explode('.', $ibexa->release), 2, '');
         $ibexaRelease = "{$majorVersion}.{$minorVersion}";

--- a/tests/bundle/SystemInfo/Collector/IbexaSystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/IbexaSystemInfoCollectorTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Bundle\SystemInfo\SystemInfo\Collector;
 
-use EzSystems\EzPlatformCoreBundle\EzPlatformCoreBundle;
+use Ibexa\Contracts\Core\Ibexa;
 use Ibexa\SystemInfo\VersionStability\VersionStabilityChecker;
 use Ibexa\Bundle\SystemInfo\SystemInfo\Collector\IbexaSystemInfoCollector;
 use Ibexa\Bundle\SystemInfo\SystemInfo\Collector\JsonComposerLockSystemInfoCollector;
@@ -38,7 +38,7 @@ class IbexaSystemInfoCollectorTest extends TestCase
         );
         $systemInfo = $systemInfoCollector->collect();
         self::assertSame(IbexaSystemInfo::PRODUCT_NAME_OSS, $systemInfo->name);
-        self::assertSame(EzPlatformCoreBundle::VERSION, $systemInfo->release);
+        self::assertSame(Ibexa::VERSION, $systemInfo->release);
     }
 }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | Part of [IBX-1466](https://issues.ibexa.co/browse/IBX-1466)
| **Requires**                            | ibexa/core#17
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

Replaced usage of `EzPlatformCoreBundle::VERSION` with `\Ibexa\Contracts\Core\Ibexa::VERSION` introduced via ibexa/core#17

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
