### PR TITLE
IBX-1466: [Composer] Dropped ezplatform-core requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,11 +38,11 @@
     },
     "autoload": {
         "psr-4": {
-            "EzSystems\\EzSupportToolsBundle\\": "src/bundle/",
-            "EzSystems\\EzSupportTools\\": "src/lib/",
             "Ibexa\\SystemInfo\\": "src/lib/",
             "Ibexa\\Bundle\\SystemInfo\\": "src/bundle/",
-            "Ibexa\\Contracts\\SystemInfo\\": "src/contracts/"
+            "Ibexa\\Contracts\\SystemInfo\\": "src/contracts/",
+            "EzSystems\\EzSupportToolsBundle\\": "src/bundle/",
+            "EzSystems\\EzSupportTools\\": "src/lib/"
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "php": "^7.3",
         "ext-json": "*",
         "ezsystems/ezplatform-kernel": "^4.0@dev",
-        "ezsystems/ezplatform-core": "^4.0@dev",
         "ezsystems/ezplatform-admin-ui": "^4.0@dev",
         "ocramius/proxy-manager": "^2.2",
         "symfony/proxy-manager-bridge": "^5.0",

--- a/tests/bundle/SystemInfo/Collector/_fixtures/composer.json
+++ b/tests/bundle/SystemInfo/Collector/_fixtures/composer.json
@@ -105,7 +105,6 @@
             "@php bin/console bazinga:js-translation:dump web/assets --merge-domains",
             "@php bin/console assetic:dump",
             "yarn install",
-            "EzSystems\\EzPlatformEncoreBundle\\Composer\\ScriptHandler::compileAssets",
             "@php bin/security-checker security:check"
         ],
         "post-install-cmd": [

--- a/tests/bundle/SystemInfo/Collector/_fixtures/corrupted_composer.json
+++ b/tests/bundle/SystemInfo/Collector/_fixtures/corrupted_composer.json
@@ -106,7 +106,6 @@
             "@php bin/console bazinga:js-translation:dump web/assets --merge-domains",
             "@php bin/console assetic:dump",
             "yarn install",
-            "EzSystems\\EzPlatformEncoreBundle\\Composer\\ScriptHandler::compileAssets",
             "@php bin/security-checker security:check"
         ],
         "post-install-cmd": [


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1466](https://issues.ibexa.co/browse/IBX-1466)
| **Requires**                            | ibexa/core#18 and ibexa/compatibility-layer#1
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

For more details see ibexa/oss#23

Usage of ezplatform-core has been already dropped via #5 (74bb51c). I dropped additionally Composer script
```composer
           "EzSystems\\EzPlatformEncoreBundle\\Composer\\ScriptHandler::compileAssets"
```

Seems the class its referencing does not exist in the current version of `EzPlatformEncoreBundle` delivered by `ezplatform-core`.

CI failure is caused by lack of cross-rebranding.

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [x] Checked that target branch is set correctly.
- [x] Asked for a review (ping `@ibexa/engineering`).




