### PR TITLE
IBX-1694: Rebranded dependency injection container service tags

### DIFF
--- a/src/bundle/DependencyInjection/Compiler/OutputFormatPass.php
+++ b/src/bundle/DependencyInjection/Compiler/OutputFormatPass.php
@@ -23,7 +23,7 @@ class OutputFormatPass implements CompilerPassInterface
             return;
         }
 
-        $outputFormattersTagged = $container->findTaggedServiceIds('support_tools.system_info.output_format');
+        $outputFormattersTagged = $container->findTaggedServiceIds('ibexa.system_info.output.format');
 
         $outputFormatters = [];
         foreach ($outputFormattersTagged as $id => $tags) {

--- a/src/bundle/DependencyInjection/Compiler/SystemInfoCollectorPass.php
+++ b/src/bundle/DependencyInjection/Compiler/SystemInfoCollectorPass.php
@@ -25,7 +25,7 @@ class SystemInfoCollectorPass implements CompilerPassInterface
             return;
         }
 
-        $infoCollectorsTagged = $container->findTaggedServiceIds('support_tools.system_info.collector');
+        $infoCollectorsTagged = $container->findTaggedServiceIds('ibexa.system_info.collector');
 
         $infoCollectors = [];
         foreach ($infoCollectorsTagged as $id => $tags) {

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -66,7 +66,7 @@ services:
             $kernelProjectDir: '%kernel.project_dir%'
             $debug: '%kernel.debug%'
         tags:
-            - { name: "support_tools.system_info.collector", identifier: "ibexa" }
+            - { name: ibexa.system_info.collector, identifier: ibexa }
 
     Ibexa\SystemInfo\VersionStability\ComposerVersionStabilityChecker: ~
 
@@ -80,7 +80,7 @@ services:
             $lockFile: "%kernel.project_dir%/composer.lock"
             $jsonFile: "%kernel.project_dir%/composer.json"
         tags:
-            - { name: "support_tools.system_info.collector", identifier: "composer" }
+            - { name: ibexa.system_info.collector, identifier: composer }
 
     Ibexa\Bundle\SystemInfo\SystemInfo\Collector\RepositorySystemInfoCollector:
         lazy: true
@@ -88,21 +88,21 @@ services:
         arguments:
             $db: '@ezpublish.persistence.connection'
         tags:
-            - { name: "support_tools.system_info.collector", identifier: "repository" }
+            - { name: ibexa.system_info.collector, identifier: repository }
 
     support_tools.system_info.collector.hardware.ezc:
         class: "%support_tools.system_info.collector.hardware.ezc.class%"
         arguments:
             - "@support_tools.system_info.ezc.wrapper"
         tags:
-            - { name: "support_tools.system_info.collector", identifier: "hardware" }
+            - { name: ibexa.system_info.collector, identifier: hardware }
 
     support_tools.system_info.collector.php.ezc:
         class: "%support_tools.system_info.collector.php.ezc.class%"
         arguments:
             - "@support_tools.system_info.ezc.wrapper"
         tags:
-            - { name: "support_tools.system_info.collector", identifier: "php" }
+            - { name: ibexa.system_info.collector, identifier: php }
 
     support_tools.system_info.collector.symfony.kernel.config:
         class: "%support_tools.system_info.collector.symfony.kernel.config.class%"
@@ -110,18 +110,18 @@ services:
             - "@kernel"
             - "%kernel.bundles%"
         tags:
-            - { name: "support_tools.system_info.collector", identifier: "symfony_kernel" }
+            - { name: ibexa.system_info.collector, identifier: symfony_kernel }
 
     Ibexa\Bundle\SystemInfo\SystemInfo\Collector\ServicesSystemInfoCollector:
         autowire: true
         tags:
-            - { name: support_tools.system_info.collector, identifier: services }
+            - { name: ibexa.system_info.collector, identifier: services }
 
     # SystemInfoOutputFormats
     support_tools.system_info.output_format.json:
         class: "%support_tools.system_info.output_format.json.class%"
         tags:
-            - { name: "support_tools.system_info.output_format", format: "json" }
+            - { name: ibexa.system_info.output.format, format: json }
 
     # Gateways
     Ibexa\SystemInfo\Storage\MetricsProvider:

--- a/src/bundle/Resources/config/systeminfo.yaml
+++ b/src/bundle/Resources/config/systeminfo.yaml
@@ -14,4 +14,4 @@ services:
             $template: '@@ezdesign/ui/tab/system_info.html.twig'
             $groupIdentifier: 'systeminfo'
         tags:
-            - { name: ezplatform.admin_ui.component, group: 'systeminfo-tab-groups' }
+            - { name: ibexa.admin_ui.component, group: 'systeminfo-tab-groups' }

--- a/src/bundle/Resources/config/view.yaml
+++ b/src/bundle/Resources/config/view.yaml
@@ -17,13 +17,13 @@ services:
             - "@ezpublish.view.configurator"
             - "@support_tools.system_info.collector_registry"
         tags:
-            - { name: ibexa.view_builder }
+            - { name: ibexa.view.builder }
 
     support_tools.view.system_info.provider:
         class: "%ezpublish.view_provider.configured.class%"
         arguments: ["@support_tools.view.matcher_factory"]
         tags:
-            - {name: ezpublish.view_provider, type: 'Ibexa\Bundle\SystemInfo\View\SystemInfoView', priority: 10}
+            - {name: ibexa.view.provider, type: 'Ibexa\Bundle\SystemInfo\View\SystemInfoView', priority: 10}
 
     support_tools.view.matcher_factory:
         class: "%ezpublish.view.matcher_factory.class%"


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1694](https://issues.ibexa.co/browse/IBX-1694)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#12

In this Pull Request we rename Ibexa's dependency injection container service tags according to the map provided by ibexa/compatibility-layer#12 as a part of the rebranding process. Backward compatibility for old service tags is provided by ibexa/compatibility-layer#12.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Asked for a review
