### PR TITLE
IBX-1696: Rebranded Container parameters and Config Resolver namespaces

### DIFF
--- a/src/bundle/DependencyInjection/IbexaSystemInfoExtension.php
+++ b/src/bundle/DependencyInjection/IbexaSystemInfoExtension.php
@@ -52,7 +52,7 @@ class IbexaSystemInfoExtension extends Extension implements PrependExtensionInte
 
         if (isset($config['system_info']) && $config['system_info']['powered_by']['enabled']) {
             $container->setParameter(
-                'ezplatform_support_tools.system_info.powered_by.name',
+                'ibexa.system_info.powered_by.name',
                 $this->getPoweredByName(
                     $container,
                     $config['system_info']['powered_by']['release']

--- a/src/bundle/Resources/config/default_settings.yaml
+++ b/src/bundle/Resources/config/default_settings.yaml
@@ -1,6 +1,6 @@
 parameters:
-    ezsettings.default.system_info_view: {}
-    ezsettings.global.system_info_view:
+    ibexa.site_access.config.default.system_info_view: {}
+    ibexa.site_access.config.global.system_info_view:
         pjax_tab:
             ibexa:
                 template: '@@ibexadesign/system_info/my_ibexa.html.twig'

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -5,7 +5,7 @@ imports:
     - { resource: events.yaml }
 
 parameters:
-    ezplatform_support_tools.system_info.powered_by.name: ''
+    ibexa.system_info.powered_by.name: ''
     ibexa.system_info.ibexa_url_list:
         contact: "https://www.ibexa.co/about-ibexa/contact-us"
         license: "https://www.ibexa.co/software-information/licenses-and-agreements"
@@ -20,12 +20,12 @@ parameters:
         update: "https://doc.ibexa.co/en/latest/updating/updating_ez_platform/"
         gpl_faq: "https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.en.html#GPLModuleLicense"
         support: "https://support.ibexa.co"
-    support_tools.ez_url_list: '%ibexa.system_info.ibexa_url_list%' # BC
+    ibexa.system_info.url_list: '%ibexa.system_info.ibexa_url_list%' # BC
 
 services:
     # EventSubscriber
     Ibexa\Bundle\SystemInfo\EventSubscriber\AddXPoweredByHeader:
-        arguments: ["%ezplatform_support_tools.system_info.powered_by.name%"]
+        arguments: ['%ibexa.system_info.powered_by.name%']
         tags:
             - { name: kernel.event_subscriber }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1696](https://issues.ibexa.co/browse/IBX-1696)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#31

Rebranded service container parameter names and Ibexa Config Resolver namespaces to follow unified pattern

### TODO

- [ ] Run regressions
- [ ] Test manually
