### PR TITLE
IBX-8135: Remove hautelook/templated-uri-bundle fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "ibexa/search": "~5.0.x-dev",
         "ibexa/test-core": "~5.0.x-dev",
         "ibexa/user": "~5.0.x-dev",
+        "hautelook/templated-uri-bundle": "^3.4",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "phpunit/phpunit": "^9.6"
     },


### PR DESCRIPTION
| :ticket: Issue | IBX-8135|
|----------------|-----------|

#### Related PRs: 
https://github.com/ibexa/oss/pull/151
https://github.com/ibexa/rest/pull/88
https://github.com/ibexa/dashboard/pull/124

#### Description:
The Ibexa fork of hautelook/templated-uri-bundle is not needed by OSS anymore. Adding the original here as it is used.

Unsure if we should bump to 4.0.

Tests should pass once https://github.com/ibexa/rest/pull/88 is merged.

#### For QA:
Sanities only.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
