### PR TITLE
IBX-8139: Dropped class_alias BC layer statements from all classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,7 @@
         "psr-4": {
             "Ibexa\\SystemInfo\\": "src/lib/",
             "Ibexa\\Bundle\\SystemInfo\\": "src/bundle/",
-            "Ibexa\\Contracts\\SystemInfo\\": "src/contracts/",
-            "EzSystems\\EzSupportToolsBundle\\": "src/bundle/",
-            "EzSystems\\EzSupportTools\\": "src/lib/"
+            "Ibexa\\Contracts\\SystemInfo\\": "src/contracts/"
         }
     },
     "autoload-dev": {

--- a/src/bundle/Command/SystemInfoDumpCommand.php
+++ b/src/bundle/Command/SystemInfoDumpCommand.php
@@ -119,5 +119,3 @@ EOD
         return ['ez-support-tools:dump-info'];
     }
 }
-
-class_alias(SystemInfoDumpCommand::class, 'EzSystems\EzSupportToolsBundle\Command\SystemInfoDumpCommand');

--- a/src/bundle/Controller/SystemInfoController.php
+++ b/src/bundle/Controller/SystemInfoController.php
@@ -63,5 +63,3 @@ class SystemInfoController extends AdminUiController
         return $response;
     }
 }
-
-class_alias(SystemInfoController::class, 'EzSystems\EzSupportToolsBundle\Controller\SystemInfoController');

--- a/src/bundle/DependencyInjection/Compiler/OutputFormatPass.php
+++ b/src/bundle/DependencyInjection/Compiler/OutputFormatPass.php
@@ -38,5 +38,3 @@ class OutputFormatPass implements CompilerPassInterface
         $outputFormatRegistryDef->setArguments([$outputFormatters]);
     }
 }
-
-class_alias(OutputFormatPass::class, 'EzSystems\EzSupportToolsBundle\DependencyInjection\Compiler\OutputFormatPass');

--- a/src/bundle/DependencyInjection/Compiler/SystemInfoCollectorPass.php
+++ b/src/bundle/DependencyInjection/Compiler/SystemInfoCollectorPass.php
@@ -39,5 +39,3 @@ class SystemInfoCollectorPass implements CompilerPassInterface
         $infoCollectorRegistryDef->setArguments([$infoCollectors]);
     }
 }
-
-class_alias(SystemInfoCollectorPass::class, 'EzSystems\EzSupportToolsBundle\DependencyInjection\Compiler\SystemInfoCollectorPass');

--- a/src/bundle/DependencyInjection/Compiler/SystemInfoTabGroupPass.php
+++ b/src/bundle/DependencyInjection/Compiler/SystemInfoTabGroupPass.php
@@ -35,5 +35,3 @@ class SystemInfoTabGroupPass implements CompilerPassInterface
         $tabRegistry->addMethodCall('addTabGroup', [$tabGroupDefinition]);
     }
 }
-
-class_alias(SystemInfoTabGroupPass::class, 'EzSystems\EzSupportToolsBundle\DependencyInjection\Compiler\SystemInfoTabGroupPass');

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -55,5 +55,3 @@ final class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 }
-
-class_alias(Configuration::class, 'EzSystems\EzSupportToolsBundle\DependencyInjection\Configuration');

--- a/src/bundle/DependencyInjection/IbexaSystemInfoExtension.php
+++ b/src/bundle/DependencyInjection/IbexaSystemInfoExtension.php
@@ -117,5 +117,3 @@ class IbexaSystemInfoExtension extends Extension implements PrependExtensionInte
         return IbexaSystemInfo::PRODUCT_NAME_VARIANTS[self::getEditionByPackages()];
     }
 }
-
-class_alias(IbexaSystemInfoExtension::class, 'EzSystems\EzSupportToolsBundle\DependencyInjection\EzSystemsEzSupportToolsExtension');

--- a/src/bundle/EventSubscriber/AddXPoweredByHeader.php
+++ b/src/bundle/EventSubscriber/AddXPoweredByHeader.php
@@ -44,5 +44,3 @@ class AddXPoweredByHeader implements EventSubscriberInterface
         }
     }
 }
-
-class_alias(AddXPoweredByHeader::class, 'EzSystems\EzSupportToolsBundle\EventSubscriber\AddXPoweredByHeader');

--- a/src/bundle/IbexaSystemInfoBundle.php
+++ b/src/bundle/IbexaSystemInfoBundle.php
@@ -33,5 +33,3 @@ class IbexaSystemInfoBundle extends Bundle
         return new IbexaSystemInfoExtension();
     }
 }
-
-class_alias(IbexaSystemInfoBundle::class, 'EzSystems\EzSupportToolsBundle\EzSystemsEzSupportToolsBundle');

--- a/src/bundle/SystemInfo/Collector/ConfigurationSymfonyKernelSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/ConfigurationSymfonyKernelSystemInfoCollector.php
@@ -64,5 +64,3 @@ class ConfigurationSymfonyKernelSystemInfoCollector implements SystemInfoCollect
         ]);
     }
 }
-
-class_alias(ConfigurationSymfonyKernelSystemInfoCollector::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Collector\ConfigurationSymfonyKernelSystemInfoCollector');

--- a/src/bundle/SystemInfo/Collector/EzcHardwareSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/EzcHardwareSystemInfoCollector.php
@@ -42,5 +42,3 @@ class EzcHardwareSystemInfoCollector implements SystemInfoCollector
         ]);
     }
 }
-
-class_alias(EzcHardwareSystemInfoCollector::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcHardwareSystemInfoCollector');

--- a/src/bundle/SystemInfo/Collector/EzcPhpSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/EzcPhpSystemInfoCollector.php
@@ -54,5 +54,3 @@ class EzcPhpSystemInfoCollector implements SystemInfoCollector
         return new PhpSystemInfo($properties);
     }
 }
-
-class_alias(EzcPhpSystemInfoCollector::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Collector\EzcPhpSystemInfoCollector');

--- a/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
@@ -286,5 +286,3 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
         return false;
     }
 }
-
-class_alias(IbexaSystemInfoCollector::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Collector\IbexaSystemInfoCollector');

--- a/src/bundle/SystemInfo/Collector/JsonComposerLockSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/JsonComposerLockSystemInfoCollector.php
@@ -195,5 +195,3 @@ class JsonComposerLockSystemInfoCollector implements SystemInfoCollector
         return $lockData['minimum-stability'] ?? null;
     }
 }
-
-class_alias(JsonComposerLockSystemInfoCollector::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Collector\JsonComposerLockSystemInfoCollector');

--- a/src/bundle/SystemInfo/Collector/RepositorySystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/RepositorySystemInfoCollector.php
@@ -69,5 +69,3 @@ class RepositorySystemInfoCollector implements SystemInfoCollector
         ]);
     }
 }
-
-class_alias(RepositorySystemInfoCollector::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Collector\RepositorySystemInfoCollector');

--- a/src/bundle/SystemInfo/Collector/SystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/SystemInfoCollector.php
@@ -21,5 +21,3 @@ interface SystemInfoCollector
      */
     public function collect();
 }
-
-class_alias(SystemInfoCollector::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Collector\SystemInfoCollector');

--- a/src/bundle/SystemInfo/Exception/ComposerFileValidationException.php
+++ b/src/bundle/SystemInfo/Exception/ComposerFileValidationException.php
@@ -18,5 +18,3 @@ final class ComposerFileValidationException extends Exception implements SystemI
         parent::__construct($message, $code, $previous);
     }
 }
-
-class_alias(ComposerFileValidationException::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Exception\ComposerFileValidationException');

--- a/src/bundle/SystemInfo/Exception/ComposerJsonFileNotFoundException.php
+++ b/src/bundle/SystemInfo/Exception/ComposerJsonFileNotFoundException.php
@@ -17,5 +17,3 @@ class ComposerJsonFileNotFoundException extends BaseNotFoundException implements
         parent::__construct('Composer.json file', $path, $previous);
     }
 }
-
-class_alias(ComposerJsonFileNotFoundException::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Exception\ComposerJsonFileNotFoundException');

--- a/src/bundle/SystemInfo/Exception/ComposerLockFileNotFoundException.php
+++ b/src/bundle/SystemInfo/Exception/ComposerLockFileNotFoundException.php
@@ -17,5 +17,3 @@ class ComposerLockFileNotFoundException extends BaseNotFoundException implements
         parent::__construct('composer.lock file', $path, $previous);
     }
 }
-
-class_alias(ComposerLockFileNotFoundException::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Exception\ComposerLockFileNotFoundException');

--- a/src/bundle/SystemInfo/Exception/MetricsNotFoundException.php
+++ b/src/bundle/SystemInfo/Exception/MetricsNotFoundException.php
@@ -17,5 +17,3 @@ class MetricsNotFoundException extends BaseNotFoundException
         parent::__construct('Metrics', $identifier, $previous);
     }
 }
-
-class_alias(MetricsNotFoundException::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Exception\MetricsNotFoundException');

--- a/src/bundle/SystemInfo/Exception/SystemInfoException.php
+++ b/src/bundle/SystemInfo/Exception/SystemInfoException.php
@@ -10,5 +10,3 @@ namespace Ibexa\Bundle\SystemInfo\SystemInfo\Exception;
 interface SystemInfoException
 {
 }
-
-class_alias(SystemInfoException::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Exception\SystemInfoException');

--- a/src/bundle/SystemInfo/EzcSystemInfoWrapper.php
+++ b/src/bundle/SystemInfo/EzcSystemInfoWrapper.php
@@ -66,5 +66,3 @@ class EzcSystemInfoWrapper
         }
     }
 }
-
-class_alias(EzcSystemInfoWrapper::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\EzcSystemInfoWrapper');

--- a/src/bundle/SystemInfo/OutputFormat.php
+++ b/src/bundle/SystemInfo/OutputFormat.php
@@ -18,5 +18,3 @@ interface OutputFormat
      */
     public function format(array $collectedInfo);
 }
-
-class_alias(OutputFormat::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\OutputFormat');

--- a/src/bundle/SystemInfo/OutputFormat/JsonOutputFormat.php
+++ b/src/bundle/SystemInfo/OutputFormat/JsonOutputFormat.php
@@ -19,5 +19,3 @@ class JsonOutputFormat implements SystemInfoOutputFormat
         return json_encode($collectedInfo, JSON_PRETTY_PRINT);
     }
 }
-
-class_alias(JsonOutputFormat::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\OutputFormat\JsonOutputFormat');

--- a/src/bundle/SystemInfo/OutputFormatRegistry.php
+++ b/src/bundle/SystemInfo/OutputFormatRegistry.php
@@ -53,5 +53,3 @@ class OutputFormatRegistry
         return array_keys($this->registry);
     }
 }
-
-class_alias(OutputFormatRegistry::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\OutputFormatRegistry');

--- a/src/bundle/SystemInfo/Registry/IdentifierBased.php
+++ b/src/bundle/SystemInfo/Registry/IdentifierBased.php
@@ -54,5 +54,3 @@ class IdentifierBased implements SystemInfoCollectorRegistry
         return array_keys($this->registry);
     }
 }
-
-class_alias(IdentifierBased::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Registry\IdentifierBased');

--- a/src/bundle/SystemInfo/SystemInfoCollectorRegistry.php
+++ b/src/bundle/SystemInfo/SystemInfoCollectorRegistry.php
@@ -35,5 +35,3 @@ interface SystemInfoCollectorRegistry
      */
     public function getIdentifiers();
 }
-
-class_alias(SystemInfoCollectorRegistry::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\SystemInfoCollectorRegistry');

--- a/src/bundle/SystemInfo/Value/ComposerPackage.php
+++ b/src/bundle/SystemInfo/Value/ComposerPackage.php
@@ -97,5 +97,3 @@ class ComposerPackage extends ValueObject implements SystemInfo
      */
     public $reference;
 }
-
-class_alias(ComposerPackage::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Value\ComposerPackage');

--- a/src/bundle/SystemInfo/Value/ComposerSystemInfo.php
+++ b/src/bundle/SystemInfo/Value/ComposerSystemInfo.php
@@ -41,5 +41,3 @@ class ComposerSystemInfo extends ValueObject implements SystemInfo
      */
     public $repositoryUrls = [];
 }
-
-class_alias(ComposerSystemInfo::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Value\ComposerSystemInfo');

--- a/src/bundle/SystemInfo/Value/HardwareSystemInfo.php
+++ b/src/bundle/SystemInfo/Value/HardwareSystemInfo.php
@@ -42,5 +42,3 @@ class HardwareSystemInfo extends ValueObject implements SystemInfo
      */
     public $memorySize;
 }
-
-class_alias(HardwareSystemInfo::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Value\HardwareSystemInfo');

--- a/src/bundle/SystemInfo/Value/IbexaSystemInfo.php
+++ b/src/bundle/SystemInfo/Value/IbexaSystemInfo.php
@@ -109,5 +109,3 @@ class IbexaSystemInfo extends ValueObject implements SystemInfo
      */
     public $composerInfo;
 }
-
-class_alias(IbexaSystemInfo::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Value\IbexaSystemInfo');

--- a/src/bundle/SystemInfo/Value/InvalidSystemInfo.php
+++ b/src/bundle/SystemInfo/Value/InvalidSystemInfo.php
@@ -21,5 +21,3 @@ final class InvalidSystemInfo extends ValueObject implements SystemInfo
      */
     public $errorMessage;
 }
-
-class_alias(InvalidSystemInfo::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Value\InvalidSystemInfo');

--- a/src/bundle/SystemInfo/Value/PhpSystemInfo.php
+++ b/src/bundle/SystemInfo/Value/PhpSystemInfo.php
@@ -57,5 +57,3 @@ class PhpSystemInfo extends ValueObject implements SystemInfo
      */
     public $acceleratorVersion;
 }
-
-class_alias(PhpSystemInfo::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Value\PhpSystemInfo');

--- a/src/bundle/SystemInfo/Value/RepositoryMetrics.php
+++ b/src/bundle/SystemInfo/Value/RepositoryMetrics.php
@@ -45,5 +45,3 @@ class RepositoryMetrics extends ValueObject implements SystemInfo
     /** @var int */
     public $contentTypesCount;
 }
-
-class_alias(RepositoryMetrics::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Value\RepositoryMetrics');

--- a/src/bundle/SystemInfo/Value/RepositorySystemInfo.php
+++ b/src/bundle/SystemInfo/Value/RepositorySystemInfo.php
@@ -57,5 +57,3 @@ class RepositorySystemInfo extends ValueObject implements SystemInfo
      */
     public $repositoryMetrics;
 }
-
-class_alias(RepositorySystemInfo::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Value\RepositorySystemInfo');

--- a/src/bundle/SystemInfo/Value/SymfonyKernelSystemInfo.php
+++ b/src/bundle/SystemInfo/Value/SymfonyKernelSystemInfo.php
@@ -90,5 +90,3 @@ class SymfonyKernelSystemInfo extends ValueObject implements SystemInfo
      */
     public $charset;
 }
-
-class_alias(SymfonyKernelSystemInfo::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Value\SymfonyKernelSystemInfo');

--- a/src/bundle/SystemInfo/Value/SystemInfo.php
+++ b/src/bundle/SystemInfo/Value/SystemInfo.php
@@ -13,5 +13,3 @@ namespace Ibexa\Bundle\SystemInfo\SystemInfo\Value;
 interface SystemInfo
 {
 }
-
-class_alias(SystemInfo::class, 'EzSystems\EzSupportToolsBundle\SystemInfo\Value\SystemInfo');

--- a/src/bundle/View/Matcher/SystemInfo/Identifier.php
+++ b/src/bundle/View/Matcher/SystemInfo/Identifier.php
@@ -72,5 +72,3 @@ class Identifier implements ViewMatcherInterface
         return mb_strtolower($normalized);
     }
 }
-
-class_alias(Identifier::class, 'EzSystems\EzSupportToolsBundle\View\Matcher\SystemInfo\Identifier');

--- a/src/bundle/View/SystemInfoView.php
+++ b/src/bundle/View/SystemInfoView.php
@@ -42,5 +42,3 @@ class SystemInfoView extends BaseView implements View
         return ['info' => $this->info];
     }
 }
-
-class_alias(SystemInfoView::class, 'EzSystems\EzSupportToolsBundle\View\SystemInfoView');

--- a/src/bundle/View/SystemInfoViewBuilder.php
+++ b/src/bundle/View/SystemInfoViewBuilder.php
@@ -66,5 +66,3 @@ class SystemInfoViewBuilder implements ViewBuilder
         return $this->registry->getItem($identifier);
     }
 }
-
-class_alias(SystemInfoViewBuilder::class, 'EzSystems\EzSupportToolsBundle\View\SystemInfoViewBuilder');

--- a/src/lib/Component/Dashboard/EzInfoTwigComponent.php
+++ b/src/lib/Component/Dashboard/EzInfoTwigComponent.php
@@ -82,5 +82,3 @@ class EzInfoTwigComponent implements Renderable
         return $urls;
     }
 }
-
-class_alias(EzInfoTwigComponent::class, 'EzSystems\EzSupportTools\Component\Dashboard\EzInfoTwigComponent');

--- a/src/lib/EventListener/ConfigureMainMenuListener.php
+++ b/src/lib/EventListener/ConfigureMainMenuListener.php
@@ -75,5 +75,3 @@ class ConfigureMainMenuListener implements EventSubscriberInterface, Translation
         ];
     }
 }
-
-class_alias(ConfigureMainMenuListener::class, 'EzSystems\EzSupportTools\EventListener\ConfigureMainMenuListener');

--- a/src/lib/EventListener/SystemInfoTabGroupListener.php
+++ b/src/lib/EventListener/SystemInfoTabGroupListener.php
@@ -66,5 +66,3 @@ class SystemInfoTabGroupListener implements EventSubscriberInterface
         }
     }
 }
-
-class_alias(SystemInfoTabGroupListener::class, 'EzSystems\EzSupportTools\EventListener\SystemInfoTabGroupListener');

--- a/src/lib/Storage/AggregateMetricsProvider.php
+++ b/src/lib/Storage/AggregateMetricsProvider.php
@@ -37,5 +37,3 @@ final class AggregateMetricsProvider implements MetricsProvider
         }
     }
 }
-
-class_alias(AggregateMetricsProvider::class, 'EzSystems\EzSupportTools\Storage\AggregateMetricsProvider');

--- a/src/lib/Storage/Metrics.php
+++ b/src/lib/Storage/Metrics.php
@@ -15,5 +15,3 @@ interface Metrics
 {
     public function getValue(): int;
 }
-
-class_alias(Metrics::class, 'EzSystems\EzSupportTools\Storage\Metrics');

--- a/src/lib/Storage/Metrics/ContentTypesCountMetrics.php
+++ b/src/lib/Storage/Metrics/ContentTypesCountMetrics.php
@@ -35,5 +35,3 @@ final class ContentTypesCountMetrics extends RepositoryConnectionAwareMetrics
         return (int) $queryBuilder->execute()->fetchColumn();
     }
 }
-
-class_alias(ContentTypesCountMetrics::class, 'EzSystems\EzSupportTools\Storage\Metrics\ContentTypesCountMetrics');

--- a/src/lib/Storage/Metrics/DraftsCountMetrics.php
+++ b/src/lib/Storage/Metrics/DraftsCountMetrics.php
@@ -47,5 +47,3 @@ final class DraftsCountMetrics extends RepositoryConnectionAwareMetrics
         return (int) $queryBuilder->execute()->fetchColumn();
     }
 }
-
-class_alias(DraftsCountMetrics::class, 'EzSystems\EzSupportTools\Storage\Metrics\DraftsCountMetrics');

--- a/src/lib/Storage/Metrics/PublishedContentObjectsCountMetrics.php
+++ b/src/lib/Storage/Metrics/PublishedContentObjectsCountMetrics.php
@@ -35,5 +35,3 @@ final class PublishedContentObjectsCountMetrics extends RepositoryConnectionAwar
         return (int) $queryBuilder->execute()->fetchColumn();
     }
 }
-
-class_alias(PublishedContentObjectsCountMetrics::class, 'EzSystems\EzSupportTools\Storage\Metrics\PublishedContentObjectsCountMetrics');

--- a/src/lib/Storage/Metrics/RepositoryConnectionAwareMetrics.php
+++ b/src/lib/Storage/Metrics/RepositoryConnectionAwareMetrics.php
@@ -34,5 +34,3 @@ abstract class RepositoryConnectionAwareMetrics implements Metrics
         return $this->connection->getDatabasePlatform()->getCountExpression($columnName);
     }
 }
-
-class_alias(RepositoryConnectionAwareMetrics::class, 'EzSystems\EzSupportTools\Storage\Metrics\RepositoryConnectionAwareMetrics');

--- a/src/lib/Storage/Metrics/UsersCountMetrics.php
+++ b/src/lib/Storage/Metrics/UsersCountMetrics.php
@@ -29,5 +29,3 @@ final class UsersCountMetrics extends RepositoryConnectionAwareMetrics
         return (int) $queryBuilder->execute()->fetchColumn();
     }
 }
-
-class_alias(UsersCountMetrics::class, 'EzSystems\EzSupportTools\Storage\Metrics\UsersCountMetrics');

--- a/src/lib/Storage/Metrics/VersionsCountMetrics.php
+++ b/src/lib/Storage/Metrics/VersionsCountMetrics.php
@@ -29,5 +29,3 @@ final class VersionsCountMetrics extends RepositoryConnectionAwareMetrics
         return (int) $queryBuilder->execute()->fetchColumn();
     }
 }
-
-class_alias(VersionsCountMetrics::class, 'EzSystems\EzSupportTools\Storage\Metrics\VersionsCountMetrics');

--- a/src/lib/Storage/MetricsProvider.php
+++ b/src/lib/Storage/MetricsProvider.php
@@ -15,5 +15,3 @@ interface MetricsProvider
 {
     public function provideMetrics(string $identifier): Metrics;
 }
-
-class_alias(MetricsProvider::class, 'EzSystems\EzSupportTools\Storage\MetricsProvider');

--- a/src/lib/Tab/SystemInfo/SystemInfoTab.php
+++ b/src/lib/Tab/SystemInfo/SystemInfoTab.php
@@ -60,5 +60,3 @@ class SystemInfoTab extends AbstractControllerBasedTab
         return /** @Ignore */$this->translator->trans(sprintf('tab.name.%s', $this->tabIdentifier), [], 'ibexa_systeminfo');
     }
 }
-
-class_alias(SystemInfoTab::class, 'EzSystems\EzSupportTools\Tab\SystemInfo\SystemInfoTab');

--- a/src/lib/Tab/SystemInfo/TabFactory.php
+++ b/src/lib/Tab/SystemInfo/TabFactory.php
@@ -57,5 +57,3 @@ class TabFactory
         );
     }
 }
-
-class_alias(TabFactory::class, 'EzSystems\EzSupportTools\Tab\SystemInfo\TabFactory');

--- a/src/lib/Value/Stability.php
+++ b/src/lib/Value/Stability.php
@@ -23,5 +23,3 @@ final class Stability
         20 => 'dev',
     ];
 }
-
-class_alias(Stability::class, 'EzSystems\EzSupportTools\Value\Stability');

--- a/src/lib/VersionStability/ComposerVersionStabilityChecker.php
+++ b/src/lib/VersionStability/ComposerVersionStabilityChecker.php
@@ -43,5 +43,3 @@ final class ComposerVersionStabilityChecker implements VersionStabilityChecker
             : null;
     }
 }
-
-class_alias(ComposerVersionStabilityChecker::class, 'EzSystems\EzSupportTools\VersionStability\ComposerVersionStabilityChecker');

--- a/src/lib/VersionStability/VersionStabilityChecker.php
+++ b/src/lib/VersionStability/VersionStabilityChecker.php
@@ -14,5 +14,3 @@ interface VersionStabilityChecker
 
     public function isStableVersion(string $version): bool;
 }
-
-class_alias(VersionStabilityChecker::class, 'EzSystems\EzSupportTools\VersionStability\VersionStabilityChecker');

--- a/tests/bundle/DependencyInjection/Compiler/SystemInfoTabGroupPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/SystemInfoTabGroupPassTest.php
@@ -44,5 +44,3 @@ class SystemInfoTabGroupPassTest extends AbstractCompilerPassTestCase
         );
     }
 }
-
-class_alias(SystemInfoTabGroupPassTest::class, 'EzSystems\EzSupportToolsBundle\Tests\DependencyInjection\Compiler\SystemInfoTabGroupPassTest');

--- a/tests/bundle/DependencyInjection/IbexaSystemInfoExtensionTest.php
+++ b/tests/bundle/DependencyInjection/IbexaSystemInfoExtensionTest.php
@@ -77,5 +77,3 @@ class IbexaSystemInfoExtensionTest extends AbstractExtensionTestCase
         }
     }
 }
-
-class_alias(IbexaSystemInfoExtensionTest::class, 'EzSystems\EzSupportToolsBundle\Tests\DependencyInjection\EzSystemsEzSupportToolsExtensionTest');

--- a/tests/bundle/SystemInfo/Collector/ConfigurationSymfonyKernelSystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/ConfigurationSymfonyKernelSystemInfoCollectorTest.php
@@ -81,5 +81,3 @@ class ConfigurationSymfonyKernelSystemInfoCollectorTest extends TestCase
         self::assertEquals($expected, $value);
     }
 }
-
-class_alias(ConfigurationSymfonyKernelSystemInfoCollectorTest::class, 'EzSystems\EzSupportToolsBundle\Tests\SystemInfo\Collector\ConfigurationSymfonyKernelSystemInfoCollectorTest');

--- a/tests/bundle/SystemInfo/Collector/EzcHardwareSystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/EzcHardwareSystemInfoCollectorTest.php
@@ -57,5 +57,3 @@ class EzcHardwareSystemInfoCollectorTest extends TestCase
         );
     }
 }
-
-class_alias(EzcHardwareSystemInfoCollectorTest::class, 'EzSystems\EzSupportToolsBundle\Tests\SystemInfo\Collector\EzcHardwareSystemInfoCollectorTest');

--- a/tests/bundle/SystemInfo/Collector/EzcPhpSystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/EzcPhpSystemInfoCollectorTest.php
@@ -68,5 +68,3 @@ class EzcPhpSystemInfoCollectorTest extends TestCase
         );
     }
 }
-
-class_alias(EzcPhpSystemInfoCollectorTest::class, 'EzSystems\EzSupportToolsBundle\Tests\SystemInfo\Collector\EzcPhpSystemInfoCollectorTest');

--- a/tests/bundle/SystemInfo/Collector/IbexaSystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/IbexaSystemInfoCollectorTest.php
@@ -42,5 +42,3 @@ class IbexaSystemInfoCollectorTest extends TestCase
         self::assertSame(Ibexa::VERSION, $systemInfo->release);
     }
 }
-
-class_alias(IbexaSystemInfoCollectorTest::class, 'EzSystems\EzSupportToolsBundle\Tests\SystemInfo\Collector\IbexaSystemInfoCollectorTest');

--- a/tests/bundle/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
@@ -150,5 +150,3 @@ class JsonComposerLockSystemInfoCollectorTest extends TestCase
         $composerCollectorCorrupted->collect();
     }
 }
-
-class_alias(JsonComposerLockSystemInfoCollectorTest::class, 'EzSystems\EzSupportToolsBundle\Tests\SystemInfo\Collector\JsonComposerLockSystemInfoCollectorTest');

--- a/tests/bundle/SystemInfo/Collector/RepositorySystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/RepositorySystemInfoCollectorTest.php
@@ -135,5 +135,3 @@ class RepositorySystemInfoCollectorTest extends TestCase
         self::assertEquals($expected, $value);
     }
 }
-
-class_alias(RepositorySystemInfoCollectorTest::class, 'EzSystems\EzSupportToolsBundle\Tests\SystemInfo\Collector\RepositorySystemInfoCollectorTest');

--- a/tests/bundle/SystemInfo/Registry/IdentifierBasedTest.php
+++ b/tests/bundle/SystemInfo/Registry/IdentifierBasedTest.php
@@ -96,5 +96,3 @@ class IdentifierBasedTest extends TestCase
         self::assertEquals($expectedIdentifiers, $actualIdentifiers);
     }
 }
-
-class_alias(IdentifierBasedTest::class, 'EzSystems\EzSupportToolsBundle\Tests\SystemInfo\Registry\IdentifierBasedTest');

--- a/tests/bundle/View/Matcher/SystemInfo/IdentitifierTest.php
+++ b/tests/bundle/View/Matcher/SystemInfo/IdentitifierTest.php
@@ -47,5 +47,3 @@ class IdentitifierTest extends TestCase
         self::assertFalse($matcher->match($view));
     }
 }
-
-class_alias(IdentitifierTest::class, 'EzSystems\EzSupportToolsBundle\Tests\View\Matcher\SystemInfo\IdentitifierTest');

--- a/tests/bundle/View/SystemInfoViewBuilderTest.php
+++ b/tests/bundle/View/SystemInfoViewBuilderTest.php
@@ -90,5 +90,3 @@ class SystemInfoViewBuilderTest extends TestCase
         return $this->collectorMock;
     }
 }
-
-class_alias(SystemInfoViewBuilderTest::class, 'EzSystems\EzSupportToolsBundle\Tests\View\SystemInfoViewBuilderTest');

--- a/tests/lib/EventListener/SystemInfoTabGroupListenerTest.php
+++ b/tests/lib/EventListener/SystemInfoTabGroupListenerTest.php
@@ -111,5 +111,3 @@ class SystemInfoTabGroupListenerTest extends TestCase
         ];
     }
 }
-
-class_alias(SystemInfoTabGroupListenerTest::class, 'EzSystems\EzSupportTools\Tests\EventListener\SystemInfoTabGroupListenerTest');

--- a/tests/lib/VersionStability/VersionStabilityCheckerTest.php
+++ b/tests/lib/VersionStability/VersionStabilityCheckerTest.php
@@ -100,5 +100,3 @@ final class VersionStabilityCheckerTest extends TestCase
         yield ['dev-test_custom', Stability::STABILITIES[20]];
     }
 }
-
-class_alias(VersionStabilityCheckerTest::class, 'EzSystems\EzSupportTools\Tests\VersionStability\VersionStabilityCheckerTest');


### PR DESCRIPTION
| :ticket: Issue | IBX-8139 |
|----------------|-----------|

#### Description:

Dropped `class_alias` BC layer statements from all classes using https://github.com/ibexa/rector/pull/2

#### For QA:

No QA needed

#### Documentation:

Document that our BC layer has been dropped
