### PR TITLE
Resolved deprecations in ibexa/system-info package

### DIFF
--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -49,7 +49,6 @@ services:
         arguments:
             $composerCollector: '@Ibexa\Bundle\SystemInfo\SystemInfo\Collector\JsonComposerLockSystemInfoCollector'
             $kernelProjectDir: '%kernel.project_dir%'
-            $debug: '%kernel.debug%'
         tags:
             - { name: ibexa.system_info.collector, identifier: ibexa }
 

--- a/src/bundle/Resources/views/themes/admin/system_info/my_ibexa.html.twig
+++ b/src/bundle/Resources/views/themes/admin/system_info/my_ibexa.html.twig
@@ -17,7 +17,7 @@
     },
     {
         label: 'ibexa.stability'|trans|desc('Stability'),
-        content: info.stability,
+        content: info.lowestStability,
     },
 ] %}
 

--- a/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
@@ -95,15 +95,6 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
     public const PACKAGE_WATCH_REGEX = '/^(doctrine|ezsystems|silversolutions|symfony)\//';
 
     /**
-     * Packages that identify installation as "Content".
-     *
-     * @deprecated Since 4.6. Use self::HEADLESS_PACKAGES const instead.
-     */
-    public const CONTENT_PACKAGES = [
-        'ibexa/content',
-    ];
-
-    /**
      * Packages that identify installation as "Headless".
      */
     public const HEADLESS_PACKAGES = [

--- a/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
@@ -106,18 +106,6 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
     ];
 
     /**
-     * Packages that identify installation as "Enterprise".
-     *
-     * @deprecated since Ibexa DXP 3.3. Rely either on <code>IbexaSystemInfoCollector::EXPERIENCE_PACKAGES</code>
-     * or <code>IbexaSystemInfoCollector::CONTENT_PACKAGES</code>.
-     */
-    public const ENTERPRISE_PACKAGES = [
-        'ibexa/page-builder',
-        'ezsystems/flex-workflow',
-        'ezsystems/landing-page-fieldtype-bundle',
-    ];
-
-    /**
      * Packages that identify installation as "Commerce".
      */
     public const COMMERCE_PACKAGES = [

--- a/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
@@ -117,29 +117,22 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
      */
     private $composerInfo;
 
-    /**
-     * @var bool
-     */
-    private $debug;
-
     /** @var string */
     private $kernelProjectDir;
 
     /**
      * @param \Ibexa\Bundle\SystemInfo\SystemInfo\Collector\JsonComposerLockSystemInfoCollector|\Ibexa\Bundle\SystemInfo\SystemInfo\Collector\SystemInfoCollector $composerCollector
-     * @param bool $debug
      */
     public function __construct(
         SystemInfoCollector $composerCollector,
         string $kernelProjectDir,
-        bool $debug = false
     ) {
         try {
             $this->composerInfo = $composerCollector->collect();
         } catch (ComposerLockFileNotFoundException | ComposerFileValidationException $e) {
             // do nothing
         }
-        $this->debug = $debug;
+
         $this->kernelProjectDir = $kernelProjectDir;
     }
 
@@ -155,7 +148,6 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
         $vendorDir = sprintf('%s/vendor/', $this->kernelProjectDir);
 
         $ibexa = new IbexaSystemInfo([
-            'debug' => $this->debug,
             'name' => IbexaSystemInfoExtension::getNameByPackages($vendorDir),
         ]);
 
@@ -193,16 +185,13 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
             return;
         }
 
-        // BC (deprecated property)
-        $ibexa->composerInfo = ['minimumStability' => $this->composerInfo->minimumStability];
-
         $dxpPackages = array_merge(
             self::HEADLESS_PACKAGES,
             self::EXPERIENCE_PACKAGES,
             self::COMMERCE_PACKAGES
         );
         $ibexa->isEnterprise = self::hasAnyPackage($this->composerInfo, $dxpPackages);
-        $ibexa->stability = $ibexa->lowestStability = self::getStability($this->composerInfo);
+        $ibexa->lowestStability = self::getStability($this->composerInfo);
     }
 
     /**

--- a/src/bundle/SystemInfo/Value/IbexaSystemInfo.php
+++ b/src/bundle/SystemInfo/Value/IbexaSystemInfo.php
@@ -22,11 +22,8 @@ class IbexaSystemInfo extends ValueObject implements SystemInfo
         'oss' => self::PRODUCT_NAME_OSS,
         'headless' => 'Ibexa Headless',
         'experience' => 'Ibexa Experience',
-        'commerce' => self::PRODUCT_NAME_COMMERCE,
+        'commerce' => 'Ibexa Commerce',
     ];
-
-    // @deprecated: use PRODUCT_NAME_VARIANTS
-    public const PRODUCT_NAME_COMMERCE = 'Ibexa Commerce';
 
     /**
      * @var string

--- a/src/bundle/SystemInfo/Value/IbexaSystemInfo.php
+++ b/src/bundle/SystemInfo/Value/IbexaSystemInfo.php
@@ -84,25 +84,4 @@ class IbexaSystemInfo extends ValueObject implements SystemInfo
      * @var string One of {@see \Ibexa\SystemInfo\Value\Stability::STABILITIES}.
      */
     public $lowestStability;
-
-    /**
-     * @deprecated Instead use $lowestStability.
-     *
-     * @var string One of {@see \Ibexa\SystemInfo\Value\Stability::STABILITIES}.
-     */
-    public $stability;
-
-    /**
-     * @deprecated Duplicates collected info on symfony
-     *
-     * @var bool
-     */
-    public $debug;
-
-    /**
-     * @deprecated This was duplication of collected info from Composer, now only contains key 'minimumStability'
-     *
-     * @var array|null
-     */
-    public $composerInfo;
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-8531 |
|----------------|-----------|

#### Related PRs: 

https://github.com/ibexa/rector/pull/5

#### Description:

Resolved deprecations in `ibexa/system-info` package.

- Removed deprecated `\Ibexa\Bundle\SystemInfo\SystemInfo\Collector\IbexaSystemInfoCollector::CONTENT_PACKAGES` const
- Removed deprecated `\Ibexa\Bundle\SystemInfo\SystemInfo\Collector\IbexaSystemInfoCollector::ENTERPRISE_PACKAGES` const
- Removed deprecated `\Ibexa\Bundle\SystemInfo\SystemInfo\Value\IbexaSystemInfo` properties


#### For QA:

N/A

#### Documentation:

Update upgrade guide. 


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
