### PR TITLE
IBX-8394: Used new RepositoryConfigurationProviderInterface contract

### DIFF
--- a/src/lib/Service/SearchEngineServiceInfo.php
+++ b/src/lib/Service/SearchEngineServiceInfo.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\SystemInfo\Service;
 
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 
 /**
  * @internal
@@ -18,9 +18,9 @@ final class SearchEngineServiceInfo implements ServiceInfo
     private const SEARCH_KEY = 'search';
     private const ENGINE_KEY = 'engine';
 
-    private RepositoryConfigurationProvider $repositoryConfigProvider;
+    private RepositoryConfigurationProviderInterface $repositoryConfigProvider;
 
-    public function __construct(RepositoryConfigurationProvider $repositoryConfigProvider)
+    public function __construct(RepositoryConfigurationProviderInterface $repositoryConfigProvider)
     {
         $this->repositoryConfigProvider = $repositoryConfigProvider;
     }


### PR DESCRIPTION
| :ticket: Issue | IBX-8394 |
|----------------|-----------|

#### Description:

Replaced usages of `\Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider`
with `\Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface`, using ibexa/rector#6.

#### For QA:

No QA needed. Regression tests should be enough.

#### Documentation:

This is code refactoring without behavior change. No documentation changes needed.
