### PR TITLE
IBX-8137: [Tests] Dropped obsolete Swift_Mailer from Kernel

### DIFF
--- a/tests/integration/Kernel.php
+++ b/tests/integration/Kernel.php
@@ -20,7 +20,6 @@ use Ibexa\Bundle\User\IbexaUserBundle;
 use Ibexa\Contracts\Test\Core\IbexaTestKernel;
 use Knp\Bundle\MenuBundle\KnpMenuBundle;
 use Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle;
-use Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -35,7 +34,6 @@ final class Kernel extends IbexaTestKernel
         yield new LexikJWTAuthenticationBundle();
         yield new HautelookTemplatedUriBundle();
         yield new WebpackEncoreBundle();
-        yield new SwiftmailerBundle();
         yield new KnpMenuBundle();
 
         yield new IbexaRestBundle();


### PR DESCRIPTION
| :ticket: Issue | IBX-8137 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Dropped obsolete swift mailer references from code base
