### PR TITLE
IBX-9413: Corrected incorrect type, changed how to retrieve variables

### DIFF
--- a/src/bundle/SystemInfo/EzcSystemInfoWrapper.php
+++ b/src/bundle/SystemInfo/EzcSystemInfoWrapper.php
@@ -28,14 +28,16 @@ class EzcSystemInfoWrapper
 
     public ?float $cpuSpeed;
 
-    /** @var int */
     public ?int $memorySize;
 
     public ?string $lineSeparator;
 
     public ?string $backupFileName;
 
-    public ?string $phpVersion;
+    /**
+     * @var array<int, string>|null
+     */
+    public ?array $phpVersion;
 
     public ?ezcSystemInfoAccelerator $phpAccelerator;
 
@@ -50,7 +52,7 @@ class EzcSystemInfoWrapper
             return;
         }
 
-        foreach (array_keys(get_object_vars($this)) as $var) {
+        foreach (array_keys(get_class_vars(self::class)) as $var) {
             $this->$var = $ezcSystemInfo->$var;
         }
     }

--- a/src/bundle/SystemInfo/EzcSystemInfoWrapper.php
+++ b/src/bundle/SystemInfo/EzcSystemInfoWrapper.php
@@ -34,9 +34,7 @@ class EzcSystemInfoWrapper
 
     public ?string $backupFileName;
 
-    /**
-     * @var array<int, string>|null
-     */
+    /** @var array<int, string>|null */
     public ?array $phpVersion;
 
     public ?ezcSystemInfoAccelerator $phpAccelerator;

--- a/tests/bundle/SystemInfo/Collector/EzcPhpSystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/EzcPhpSystemInfoCollectorTest.php
@@ -30,7 +30,7 @@ class EzcPhpSystemInfoCollectorTest extends TestCase
             ->getMockBuilder(EzcSystemInfoWrapper::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->ezcSystemInfoMock->phpVersion = PHP_VERSION;
+        $this->ezcSystemInfoMock->phpVersion = explode('.', PHP_VERSION);
 
         $this->ezcSystemInfoMock->phpAccelerator = $this
             ->getMockBuilder(ezcSystemInfoAccelerator::class)
@@ -60,7 +60,7 @@ class EzcPhpSystemInfoCollectorTest extends TestCase
 
         self::assertEquals(
             new PhpSystemInfo([
-                'version' => $this->ezcSystemInfoMock->phpVersion,
+                'version' => implode('.', $this->ezcSystemInfoMock->phpVersion ?? []),
                 'acceleratorEnabled' => $this->ezcSystemInfoMock->phpAccelerator->isEnabled,
                 'acceleratorName' => $this->ezcSystemInfoMock->phpAccelerator->name,
                 'acceleratorURL' => $this->ezcSystemInfoMock->phpAccelerator->url,


### PR DESCRIPTION
| :ticket: Issue | IBX-9413 |
|----------------|-----------|

`get_object_vars` - uninitialized properties are considered inaccessible, and thus will not be included in the array. 

If we use types for variables they are treated as uninitialized, which is why the get_object_vars function cannot retrieve them. I also don't see the point of assigning null to each variable to initialize it. During the last change, unfortunately, phpVersion was set to string instead of an array, which after fixing the problem with retrieving variables caused a new error


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
