### PR TITLE
EZP-32460: Move problematic call to SystemInfoCollector::collect to outside of constructor

### DIFF
--- a/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
@@ -133,6 +133,11 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
     ];
 
     /**
+     * @var \Ibexa\Bundle\SystemInfo\SystemInfo\Collector\SystemInfoCollector
+     */
+    private $systemInfoCollector;
+
+    /**
      * @var \Ibexa\Bundle\SystemInfo\SystemInfo\Value\ComposerSystemInfo|null
      */
     private $composerInfo;
@@ -150,15 +155,8 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
         string $kernelProjectDir,
         bool $debug = false
     ) {
-        try {
-            $composerInfo = $composerCollector->collect();
-            if ($composerInfo instanceof ComposerSystemInfo) {
-                $this->composerInfo = $composerInfo;
-            }
-        } catch (ComposerLockFileNotFoundException | ComposerFileValidationException $e) {
-            // do nothing
-        }
         $this->debug = $debug;
+        $this->systemInfoCollector = $composerCollector;
         $this->kernelProjectDir = $kernelProjectDir;
     }
 
@@ -171,6 +169,17 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
      */
     public function collect(): IbexaSystemInfo
     {
+        if($this->composerInfo === null) {
+            try {
+                $composerInfo = $this->systemInfoCollector->collect();
+                if ($composerInfo instanceof ComposerSystemInfo) {
+                    $this->composerInfo = $composerInfo;
+                }
+            } catch (ComposerLockFileNotFoundException | ComposerFileValidationException $e) {
+            // do nothing
+            }
+        }
+
         $vendorDir = sprintf('%s/vendor/', $this->kernelProjectDir);
 
         $ibexa = new IbexaSystemInfo([

--- a/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
@@ -169,14 +169,14 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
      */
     public function collect(): IbexaSystemInfo
     {
-        if($this->composerInfo === null) {
+        if ($this->composerInfo === null) {
             try {
                 $composerInfo = $this->systemInfoCollector->collect();
                 if ($composerInfo instanceof ComposerSystemInfo) {
                     $this->composerInfo = $composerInfo;
                 }
             } catch (ComposerLockFileNotFoundException | ComposerFileValidationException $e) {
-            // do nothing
+                // do nothing
             }
         }
 

--- a/tests/bundle/SystemInfo/Collector/IbexaSystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/IbexaSystemInfoCollectorTest.php
@@ -40,6 +40,25 @@ class IbexaSystemInfoCollectorTest extends TestCase
         $systemInfo = $systemInfoCollector->collect();
         self::assertSame(IbexaSystemInfo::PRODUCT_NAME_OSS, $systemInfo->name);
         self::assertSame(Ibexa::VERSION, $systemInfo->release);
+
+        // Test that information from the composer.json file is correctly extracted
+        self::assertSame('dev', $systemInfo->lowestStability);
+    }
+
+    public function testCollectWithInvalidComposerJson(): void
+    {
+        $composerCollector = new JsonComposerLockSystemInfoCollector(
+            $this->versionStabilityChecker,
+            __DIR__ . '/_fixtures/corrupted_composer.lock',
+            __DIR__ . '/_fixtures/corrupted_composer.json'
+        );
+
+        $systemInfoCollector = new IbexaSystemInfoCollector(
+            $composerCollector,
+            dirname(__DIR__, 5)
+        );
+        $systemInfo = $systemInfoCollector->collect();
+        self::assertNull($systemInfo->lowestStability);
     }
 }
 


### PR DESCRIPTION
# What
Removes problematic call to FS bound function. This _should_ **globally** cut ibexa platform request processing times by ~ 7 MS depending on the size of the composer.lock file and the storage medium being queried.
See https://issues.ibexa.co/browse/EZP-32460 for more details

# How
By moving the actual parsing of the composer.lock file to when it is required by calls to `IbexaSystemInfoCollector::collect`  instead of the `__construct` method where it is seemingly invoked most requests

# Why
Over a large number of requests, especially many short ones this particular call can result in noticeable performance degradation compounded in N+1 scenarios where this code path can be hit many times over the course of a number of requests or longer term use of the admin UI cc @ibexa/php-dev