### PR TITLE
IBX-9584: Resolved Symfony 6.x deprecations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,31 @@ jobs:
       - name: Run code style check
         run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
+  rector:
+    name: Run rector
+    runs-on: "ubuntu-22.04"
+    strategy:
+      matrix:
+        php:
+          - '8.3'
+    steps:
+      -   uses: actions/checkout@v4
+
+      -   name: Setup PHP Action
+          uses: shivammathur/setup-php@v2
+          with:
+            php-version: ${{ matrix.php }}
+            coverage: none
+            extensions: 'pdo_sqlite, gd'
+            tools: cs2pr
+
+      -   uses: ramsey/composer-install@v3
+          with:
+            dependency-versions: highest
+
+      -   name: Run rector
+          run: vendor/bin/rector process --dry-run --ansi
+
   tests:
     name: Tests
     runs-on: "ubuntu-22.04"

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "ibexa/http-cache": "~5.0.x-dev",
         "ibexa/notifications": "~5.0.x-dev",
         "ibexa/phpstan": "~5.0.x-dev",
+        "ibexa/rector": "~5.0.x-dev",
         "ibexa/rest": "~5.0.x-dev",
         "ibexa/search": "~5.0.x-dev",
         "ibexa/test-core": "~5.0.x-dev",
@@ -29,9 +30,9 @@
         "hautelook/templated-uri-bundle": "^3.4",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "phpunit/phpunit": "^9.6",
-        "phpstan/phpstan": "^2.0",
-        "phpstan/phpstan-phpunit": "^2.0",
-        "phpstan/phpstan-symfony": "^2.0"
+        "phpstan/phpstan": "^1.12",
+        "phpstan/phpstan-phpunit": "^1.4",
+        "phpstan/phpstan-symfony": "^1.4"
     },
     "autoload": {
         "psr-4": {

--- a/rector.php
+++ b/rector.php
@@ -19,4 +19,7 @@ return RectorConfig::configure()
         IbexaSetList::IBEXA_50->value,
         SymfonySetList::SYMFONY_60,
         SymfonySetList::SYMFONY_61,
+        SymfonySetList::SYMFONY_62,
+        SymfonySetList::SYMFONY_63,
+        SymfonySetList::SYMFONY_64,
     ]);

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Ibexa\Contracts\Rector\Sets\IbexaSetList;
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Set\SymfonySetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withSets([
+        IbexaSetList::IBEXA_50->value,
+        SymfonySetList::SYMFONY_60,
+        SymfonySetList::SYMFONY_61,
+    ]);

--- a/src/bundle/Command/SystemInfoDumpCommand.php
+++ b/src/bundle/Command/SystemInfoDumpCommand.php
@@ -18,12 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
     name: 'ibexa:system-info:dump',
-    description: 'Collects system information and dumps it.',
-    aliases: [
-        'ez-support-tools:dump-info',
-        'ibexa:dump-info',
-        'ibexa:info',
-    ]
+    description: 'Collects system information and dumps it.'
 )]
 final class SystemInfoDumpCommand extends Command
 {

--- a/src/bundle/Command/SystemInfoDumpCommand.php
+++ b/src/bundle/Command/SystemInfoDumpCommand.php
@@ -9,12 +9,22 @@ namespace Ibexa\Bundle\SystemInfo\Command;
 
 use Ibexa\Bundle\SystemInfo\SystemInfo\OutputFormatRegistry;
 use Ibexa\Bundle\SystemInfo\SystemInfo\SystemInfoCollectorRegistry;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'ibexa:system-info:dump',
+    description: 'Collects system information and dumps it.',
+    aliases: [
+        'ez-support-tools:dump-info',
+        'ibexa:dump-info',
+        'ibexa:info',
+    ]
+)]
 final class SystemInfoDumpCommand extends Command
 {
     private SystemInfoCollectorRegistry $systemInfoCollectorRegistry;
@@ -32,13 +42,6 @@ final class SystemInfoDumpCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ibexa:system-info:dump')
-            ->setAliases([
-                'ez-support-tools:dump-info',
-                'ibexa:dump-info',
-                'ibexa:info',
-            ])
-            ->setDescription('Collects system information and dumps it.')
             ->setHelp(
                 <<<'EOD'
 By default it dumps information from all available information collectors.


### PR DESCRIPTION
| :ticket: Issue | IBX-9584  |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Enabled and executed automatic refactoring rules defined for Symfony 6.x.

* [CLI] Replaced deprecated Command::{$defaultName, $defaultDescription} with the AsCommand attribute
* [CLI] Dropped deprecated command aliases

Additionally added rector job to CI setup to prevent merging up code which is not compatible with Symfony 6+.

#### For QA:
Sanities.

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
