### PR TITLE
IBX-9727: Added missing type hints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "zetacomponents/system-information": "^1.1.1"
     },
     "require-dev": {
+        "hautelook/templated-uri-bundle": "^3.4",
         "ibexa/code-style": "~2.0.0",
         "ibexa/content-forms": "~5.0.x-dev",
         "ibexa/design-engine": "~5.0.x-dev",
@@ -27,12 +28,11 @@
         "ibexa/search": "~5.0.x-dev",
         "ibexa/test-core": "~5.0.x-dev",
         "ibexa/user": "~5.0.x-dev",
-        "hautelook/templated-uri-bundle": "^3.4",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
-        "phpunit/phpunit": "^9.6",
-        "phpstan/phpstan": "^1.12",
-        "phpstan/phpstan-phpunit": "^1.4",
-        "phpstan/phpstan-symfony": "^1.4"
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-symfony": "^2.0",
+        "phpunit/phpunit": "^9.6"
     },
     "autoload": {
         "psr-4": {

--- a/src/bundle/Controller/SystemInfoController.php
+++ b/src/bundle/Controller/SystemInfoController.php
@@ -15,8 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SystemInfoController extends AdminUiController
 {
-    /** @var \Ibexa\Bundle\SystemInfo\SystemInfo\SystemInfoCollectorRegistry */
-    protected $collectorRegistry;
+    protected SystemInfoCollectorRegistry $collectorRegistry;
 
     /**
      * @param \Ibexa\Bundle\SystemInfo\SystemInfo\SystemInfoCollectorRegistry $collectorRegistry

--- a/src/bundle/EventSubscriber/AddXPoweredByHeader.php
+++ b/src/bundle/EventSubscriber/AddXPoweredByHeader.php
@@ -20,7 +20,7 @@ class AddXPoweredByHeader implements EventSubscriberInterface
     /**
      * @var string If empty, this powered by header is skipped.
      */
-    private $installationName;
+    private string $installationName;
 
     public function __construct(string $installationName)
     {

--- a/src/bundle/SystemInfo/Collector/ConfigurationSymfonyKernelSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/ConfigurationSymfonyKernelSystemInfoCollector.php
@@ -17,10 +17,8 @@ class ConfigurationSymfonyKernelSystemInfoCollector implements SystemInfoCollect
 {
     /**
      * Symfony kernel.
-     *
-     * @var \Symfony\Component\HttpKernel\Kernel
      */
-    private $kernel;
+    private Kernel $kernel;
 
     /**
      * Installed bundles.
@@ -35,7 +33,7 @@ class ConfigurationSymfonyKernelSystemInfoCollector implements SystemInfoCollect
      *
      * @var array<string, class-string>
      */
-    private $bundles;
+    private array $bundles;
 
     /**
      * @param array<string, class-string> $bundles

--- a/src/bundle/SystemInfo/Collector/EzcHardwareSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/EzcHardwareSystemInfoCollector.php
@@ -15,10 +15,7 @@ use Ibexa\Bundle\SystemInfo\SystemInfo\Value\HardwareSystemInfo;
  */
 class EzcHardwareSystemInfoCollector implements SystemInfoCollector
 {
-    /**
-     * @var \Ibexa\Bundle\SystemInfo\SystemInfo\EzcSystemInfoWrapper
-     */
-    private $ezcSystemInfo;
+    private EzcSystemInfoWrapper $ezcSystemInfo;
 
     public function __construct(EzcSystemInfoWrapper $ezcSystemInfo)
     {

--- a/src/bundle/SystemInfo/Collector/EzcPhpSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/EzcPhpSystemInfoCollector.php
@@ -15,10 +15,7 @@ use Ibexa\Bundle\SystemInfo\SystemInfo\Value\PhpSystemInfo;
  */
 class EzcPhpSystemInfoCollector implements SystemInfoCollector
 {
-    /**
-     * @var \Ibexa\Bundle\SystemInfo\SystemInfo\EzcSystemInfoWrapper
-     */
-    private $ezcSystemInfo;
+    private EzcSystemInfoWrapper $ezcSystemInfo;
 
     public function __construct(EzcSystemInfoWrapper $ezcSystemInfo)
     {

--- a/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/IbexaSystemInfoCollector.php
@@ -115,15 +115,14 @@ class IbexaSystemInfoCollector implements SystemInfoCollector
     /**
      * @var \Ibexa\Bundle\SystemInfo\SystemInfo\Collector\SystemInfoCollector
      */
-    private $systemInfoCollector;
+    private SystemInfoCollector $systemInfoCollector;
 
     /**
      * @var \Ibexa\Bundle\SystemInfo\SystemInfo\Value\ComposerSystemInfo|null
      */
-    private $composerInfo;
+    private ?ComposerSystemInfo $composerInfo = null;
 
-    /** @var string */
-    private $kernelProjectDir;
+    private string $kernelProjectDir;
 
     /**
      * @param \Ibexa\Bundle\SystemInfo\SystemInfo\Collector\JsonComposerLockSystemInfoCollector|\Ibexa\Bundle\SystemInfo\SystemInfo\Collector\SystemInfoCollector $composerCollector

--- a/src/bundle/SystemInfo/Collector/RepositorySystemInfoCollector.php
+++ b/src/bundle/SystemInfo/Collector/RepositorySystemInfoCollector.php
@@ -19,17 +19,13 @@ class RepositorySystemInfoCollector implements SystemInfoCollector
 {
     /**
      * The database connection, only used to retrieve some information on the database itself.
-     *
-     * @var \Doctrine\DBAL\Connection
      */
-    private $connection;
+    private Connection $connection;
 
     /**
      * The metrics provider needed to populate Repository value object consisting of several metrics.
-     *
-     * @var \Ibexa\SystemInfo\Storage\MetricsProvider
      */
-    private $metricsProvider;
+    private MetricsProvider $metricsProvider;
 
     public function __construct(Connection $db, MetricsProvider $metricsProvider)
     {

--- a/src/bundle/SystemInfo/OutputFormat/JsonOutputFormat.php
+++ b/src/bundle/SystemInfo/OutputFormat/JsonOutputFormat.php
@@ -14,7 +14,7 @@ use Ibexa\Bundle\SystemInfo\SystemInfo\OutputFormat as SystemInfoOutputFormat;
  */
 class JsonOutputFormat implements SystemInfoOutputFormat
 {
-    public function format(array $collectedInfo)
+    public function format(array $collectedInfo): string
     {
         $json = json_encode($collectedInfo, JSON_PRETTY_PRINT);
         if ($json === false) {

--- a/src/bundle/SystemInfo/Registry/IdentifierBased.php
+++ b/src/bundle/SystemInfo/Registry/IdentifierBased.php
@@ -16,7 +16,7 @@ use Ibexa\Core\Base\Exceptions\NotFoundException;
 class IdentifierBased implements SystemInfoCollectorRegistry
 {
     /** @var \Ibexa\Bundle\SystemInfo\SystemInfo\Collector\SystemInfoCollector[] */
-    private $registry = [];
+    private array $registry;
 
     /**
      * @param \Ibexa\Bundle\SystemInfo\SystemInfo\Collector\SystemInfoCollector[] $items Hash of SystemInfoCollectors, with identifier string as key.

--- a/src/bundle/View/SystemInfoViewBuilder.php
+++ b/src/bundle/View/SystemInfoViewBuilder.php
@@ -17,17 +17,12 @@ use Ibexa\Core\MVC\Symfony\View\View;
 
 class SystemInfoViewBuilder implements ViewBuilder
 {
-    /**
-     * @var \Ibexa\Core\MVC\Symfony\View\Configurator
-     */
-    private $viewConfigurator;
+    private Configurator $viewConfigurator;
 
     /**
      * System info collector registry.
-     *
-     * @var \Ibexa\Bundle\SystemInfo\SystemInfo\SystemInfoCollectorRegistry
      */
-    private $registry;
+    private SystemInfoCollectorRegistry $registry;
 
     public function __construct(Configurator $viewConfigurator, SystemInfoCollectorRegistry $registry)
     {

--- a/src/lib/EventListener/ConfigureMainMenuListener.php
+++ b/src/lib/EventListener/ConfigureMainMenuListener.php
@@ -20,11 +20,9 @@ class ConfigureMainMenuListener implements EventSubscriberInterface, Translation
 {
     public const ITEM_ADMIN__SYSTEMINFO = 'main__admin__systeminfo';
 
-    /** @var \Ibexa\Contracts\AdminUi\Menu\MenuItemFactoryInterface */
-    private $menuItemFactory;
+    private MenuItemFactoryInterface $menuItemFactory;
 
-    /** @var \Ibexa\Contracts\Core\Repository\PermissionResolver */
-    private $permissionResolver;
+    private PermissionResolver $permissionResolver;
 
     public function __construct(
         MenuItemFactoryInterface $menuItemFactory,

--- a/src/lib/EventListener/SystemInfoTabGroupListener.php
+++ b/src/lib/EventListener/SystemInfoTabGroupListener.php
@@ -16,14 +16,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class SystemInfoTabGroupListener implements EventSubscriberInterface
 {
-    /** @var \Ibexa\AdminUi\Tab\TabRegistry */
-    protected $tabRegistry;
+    protected TabRegistry $tabRegistry;
 
-    /** @var \Ibexa\SystemInfo\Tab\SystemInfo\TabFactory */
-    protected $tabFactory;
+    protected TabFactory $tabFactory;
 
-    /** @var \Ibexa\Bundle\SystemInfo\SystemInfo\SystemInfoCollectorRegistry */
-    protected $systeminfoCollectorRegistry;
+    protected SystemInfoCollectorRegistry $systeminfoCollectorRegistry;
 
     /**
      * @param \Ibexa\AdminUi\Tab\TabRegistry $tabRegistry

--- a/src/lib/Storage/Metrics/RepositoryConnectionAwareMetrics.php
+++ b/src/lib/Storage/Metrics/RepositoryConnectionAwareMetrics.php
@@ -16,8 +16,7 @@ use Ibexa\SystemInfo\Storage\Metrics;
  */
 abstract class RepositoryConnectionAwareMetrics implements Metrics
 {
-    /** @var \Doctrine\DBAL\Connection */
-    protected $connection;
+    protected Connection $connection;
 
     abstract public function getValue(): int;
 

--- a/src/lib/Tab/SystemInfo/SystemInfoTab.php
+++ b/src/lib/Tab/SystemInfo/SystemInfoTab.php
@@ -16,11 +16,9 @@ use Twig\Environment;
 
 class SystemInfoTab extends AbstractControllerBasedTab
 {
-    /** @var string */
-    protected $tabIdentifier;
+    protected string $tabIdentifier;
 
-    /** @var string */
-    protected $collectorIdentifier;
+    protected string $collectorIdentifier;
 
     /**
      * @param \Twig\Environment $twig

--- a/src/lib/Tab/SystemInfo/TabFactory.php
+++ b/src/lib/Tab/SystemInfo/TabFactory.php
@@ -14,14 +14,11 @@ use Twig\Environment;
 
 class TabFactory
 {
-    /** @var \Symfony\Bridge\Twig\Extension\HttpKernelRuntime */
-    protected $httpKernelRuntime;
+    protected HttpKernelRuntime $httpKernelRuntime;
 
-    /** @var \Twig\Environment */
-    protected $twig;
+    protected Environment $twig;
 
-    /** @var \Symfony\Contracts\Translation\TranslatorInterface */
-    protected $translator;
+    protected TranslatorInterface $translator;
 
     /**
      * @param \Twig\Environment $twig

--- a/tests/bundle/DependencyInjection/Compiler/SystemInfoTabGroupPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/SystemInfoTabGroupPassTest.php
@@ -23,9 +23,6 @@ class SystemInfoTabGroupPassTest extends AbstractCompilerPassTestCase
         $this->setDefinition(TabRegistry::class, new Definition());
     }
 
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     */
     protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new SystemInfoTabGroupPass());

--- a/tests/bundle/SystemInfo/Collector/EzcHardwareSystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/EzcHardwareSystemInfoCollectorTest.php
@@ -15,14 +15,8 @@ use PHPUnit\Framework\TestCase;
 
 class EzcHardwareSystemInfoCollectorTest extends TestCase
 {
-    /**
-     * @var \Ibexa\Bundle\SystemInfo\SystemInfo\EzcSystemInfoWrapper|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private MockObject $ezcSystemInfoMock;
+    private EzcSystemInfoWrapper&MockObject $ezcSystemInfoMock;
 
-    /**
-     * @var \Ibexa\Bundle\SystemInfo\SystemInfo\Collector\EzcHardwareSystemInfoCollector
-     */
     private EzcHardwareSystemInfoCollector $ezcHardware;
 
     protected function setUp(): void
@@ -45,8 +39,6 @@ class EzcHardwareSystemInfoCollectorTest extends TestCase
     public function testCollect(): void
     {
         $value = $this->ezcHardware->collect();
-
-        self::assertInstanceOf(HardwareSystemInfo::class, $value);
 
         self::assertEquals(
             new HardwareSystemInfo([

--- a/tests/bundle/SystemInfo/Collector/EzcHardwareSystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/EzcHardwareSystemInfoCollectorTest.php
@@ -10,6 +10,7 @@ namespace Ibexa\Tests\Bundle\SystemInfo\SystemInfo\Collector;
 use Ibexa\Bundle\SystemInfo\SystemInfo\Collector\EzcHardwareSystemInfoCollector;
 use Ibexa\Bundle\SystemInfo\SystemInfo\EzcSystemInfoWrapper;
 use Ibexa\Bundle\SystemInfo\SystemInfo\Value\HardwareSystemInfo;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class EzcHardwareSystemInfoCollectorTest extends TestCase
@@ -17,12 +18,12 @@ class EzcHardwareSystemInfoCollectorTest extends TestCase
     /**
      * @var \Ibexa\Bundle\SystemInfo\SystemInfo\EzcSystemInfoWrapper|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $ezcSystemInfoMock;
+    private MockObject $ezcSystemInfoMock;
 
     /**
      * @var \Ibexa\Bundle\SystemInfo\SystemInfo\Collector\EzcHardwareSystemInfoCollector
      */
-    private $ezcHardware;
+    private EzcHardwareSystemInfoCollector $ezcHardware;
 
     protected function setUp(): void
     {

--- a/tests/bundle/SystemInfo/Collector/EzcPhpSystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/EzcPhpSystemInfoCollectorTest.php
@@ -16,14 +16,8 @@ use PHPUnit\Framework\TestCase;
 
 class EzcPhpSystemInfoCollectorTest extends TestCase
 {
-    /**
-     * @var \Ibexa\Bundle\SystemInfo\SystemInfo\EzcSystemInfoWrapper|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private MockObject $ezcSystemInfoMock;
+    private EzcSystemInfoWrapper&MockObject $ezcSystemInfoMock;
 
-    /**
-     * @var \Ibexa\Bundle\SystemInfo\SystemInfo\Collector\EzcPhpSystemInfoCollector
-     */
     private EzcPhpSystemInfoCollector $ezcPhpCollector;
 
     protected function setUp(): void
@@ -57,7 +51,6 @@ class EzcPhpSystemInfoCollectorTest extends TestCase
     {
         $value = $this->ezcPhpCollector->collect();
 
-        self::assertInstanceOf(PhpSystemInfo::class, $value);
         self::assertInstanceOf(ezcSystemInfoAccelerator::class, $this->ezcSystemInfoMock->phpAccelerator);
 
         self::assertEquals(

--- a/tests/bundle/SystemInfo/Collector/EzcPhpSystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/EzcPhpSystemInfoCollectorTest.php
@@ -11,6 +11,7 @@ use ezcSystemInfoAccelerator;
 use Ibexa\Bundle\SystemInfo\SystemInfo\Collector\EzcPhpSystemInfoCollector;
 use Ibexa\Bundle\SystemInfo\SystemInfo\EzcSystemInfoWrapper;
 use Ibexa\Bundle\SystemInfo\SystemInfo\Value\PhpSystemInfo;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class EzcPhpSystemInfoCollectorTest extends TestCase
@@ -18,12 +19,12 @@ class EzcPhpSystemInfoCollectorTest extends TestCase
     /**
      * @var \Ibexa\Bundle\SystemInfo\SystemInfo\EzcSystemInfoWrapper|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $ezcSystemInfoMock;
+    private MockObject $ezcSystemInfoMock;
 
     /**
      * @var \Ibexa\Bundle\SystemInfo\SystemInfo\Collector\EzcPhpSystemInfoCollector
      */
-    private $ezcPhpCollector;
+    private EzcPhpSystemInfoCollector $ezcPhpCollector;
 
     protected function setUp(): void
     {

--- a/tests/bundle/SystemInfo/Collector/IbexaSystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/IbexaSystemInfoCollectorTest.php
@@ -13,12 +13,13 @@ use Ibexa\Bundle\SystemInfo\SystemInfo\Collector\JsonComposerLockSystemInfoColle
 use Ibexa\Bundle\SystemInfo\SystemInfo\Value\IbexaSystemInfo;
 use Ibexa\Contracts\Core\Ibexa;
 use Ibexa\SystemInfo\VersionStability\VersionStabilityChecker;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class IbexaSystemInfoCollectorTest extends TestCase
 {
     /** @var \Ibexa\SystemInfo\VersionStability\VersionStabilityChecker|\PHPUnit\Framework\MockObject\MockObject */
-    private $versionStabilityChecker;
+    private MockObject $versionStabilityChecker;
 
     public function setUp(): void
     {

--- a/tests/bundle/SystemInfo/Collector/IbexaSystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/IbexaSystemInfoCollectorTest.php
@@ -18,8 +18,7 @@ use PHPUnit\Framework\TestCase;
 
 class IbexaSystemInfoCollectorTest extends TestCase
 {
-    /** @var \Ibexa\SystemInfo\VersionStability\VersionStabilityChecker|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $versionStabilityChecker;
+    private VersionStabilityChecker&MockObject $versionStabilityChecker;
 
     public function setUp(): void
     {

--- a/tests/bundle/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
@@ -14,12 +14,13 @@ use Ibexa\Bundle\SystemInfo\SystemInfo\Exception\ComposerLockFileNotFoundExcepti
 use Ibexa\Bundle\SystemInfo\SystemInfo\Value\ComposerPackage;
 use Ibexa\Bundle\SystemInfo\SystemInfo\Value\ComposerSystemInfo;
 use Ibexa\SystemInfo\VersionStability\VersionStabilityChecker;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class JsonComposerLockSystemInfoCollectorTest extends TestCase
 {
     /** @var \Ibexa\SystemInfo\VersionStability\VersionStabilityChecker|\PHPUnit\Framework\MockObject\MockObject */
-    private $versionStabilityChecker;
+    private MockObject $versionStabilityChecker;
 
     public function setUp(): void
     {

--- a/tests/bundle/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/JsonComposerLockSystemInfoCollectorTest.php
@@ -19,8 +19,7 @@ use PHPUnit\Framework\TestCase;
 
 class JsonComposerLockSystemInfoCollectorTest extends TestCase
 {
-    /** @var \Ibexa\SystemInfo\VersionStability\VersionStabilityChecker|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $versionStabilityChecker;
+    private VersionStabilityChecker&MockObject $versionStabilityChecker;
 
     public function setUp(): void
     {

--- a/tests/bundle/SystemInfo/Collector/RepositorySystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/RepositorySystemInfoCollectorTest.php
@@ -19,29 +19,14 @@ use PHPUnit\Framework\TestCase;
 
 class RepositorySystemInfoCollectorTest extends TestCase
 {
-    /**
-     * @var \Doctrine\DBAL\Connection|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private MockObject $dbalConnectionMock;
+    private Connection&MockObject $dbalConnectionMock;
 
-    /**
-     * @var \Doctrine\DBAL\Platforms\AbstractPlatform&\PHPUnit\Framework\MockObject\MockObject
-     */
-    private MockObject $dbalPlatformMock;
+    private AbstractPlatform&MockObject $dbalPlatformMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
-     */
-    private MockObject $metricsProviderMock;
+    private MetricsProvider&MockObject $metricsProviderMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
-     */
-    private MockObject $metricsMock;
+    private Metrics&MockObject $metricsMock;
 
-    /**
-     * @var \Ibexa\Bundle\SystemInfo\SystemInfo\Collector\RepositorySystemInfoCollector
-     */
     private RepositorySystemInfoCollector $repositoryCollector;
 
     protected function setUp(): void
@@ -132,7 +117,6 @@ class RepositorySystemInfoCollectorTest extends TestCase
 
         $value = $this->repositoryCollector->collect();
 
-        self::assertInstanceOf(RepositorySystemInfo::class, $value);
         self::assertEquals($expected, $value);
     }
 }

--- a/tests/bundle/SystemInfo/Collector/RepositorySystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/RepositorySystemInfoCollectorTest.php
@@ -14,6 +14,7 @@ use Ibexa\Bundle\SystemInfo\SystemInfo\Value\RepositoryMetrics;
 use Ibexa\Bundle\SystemInfo\SystemInfo\Value\RepositorySystemInfo;
 use Ibexa\SystemInfo\Storage\Metrics;
 use Ibexa\SystemInfo\Storage\MetricsProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class RepositorySystemInfoCollectorTest extends TestCase
@@ -21,27 +22,27 @@ class RepositorySystemInfoCollectorTest extends TestCase
     /**
      * @var \Doctrine\DBAL\Connection|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $dbalConnectionMock;
+    private MockObject $dbalConnectionMock;
 
     /**
      * @var \Doctrine\DBAL\Platforms\AbstractPlatform&\PHPUnit\Framework\MockObject\MockObject
      */
-    private $dbalPlatformMock;
+    private MockObject $dbalPlatformMock;
 
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject
      */
-    private $metricsProviderMock;
+    private MockObject $metricsProviderMock;
 
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject
      */
-    private $metricsMock;
+    private MockObject $metricsMock;
 
     /**
      * @var \Ibexa\Bundle\SystemInfo\SystemInfo\Collector\RepositorySystemInfoCollector
      */
-    private $repositoryCollector;
+    private RepositorySystemInfoCollector $repositoryCollector;
 
     protected function setUp(): void
     {

--- a/tests/bundle/SystemInfo/Collector/ServicesSystemInfoCollectorTest.php
+++ b/tests/bundle/SystemInfo/Collector/ServicesSystemInfoCollectorTest.php
@@ -10,18 +10,13 @@ namespace Ibexa\Tests\Bundle\SystemInfo\SystemInfo\Collector;
 use Ibexa\Bundle\SystemInfo\SystemInfo\Collector\ServicesSystemInfoCollector;
 use Ibexa\Bundle\SystemInfo\SystemInfo\Value\ServicesSystemInfo;
 use Ibexa\SystemInfo\Service\ServiceProviderInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class ServicesSystemInfoCollectorTest extends TestCase
 {
-    /**
-     * @var \Ibexa\SystemInfo\Service\ServiceProviderInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private ServiceProviderInterface $serviceProviderMock;
+    private ServiceProviderInterface&MockObject $serviceProviderMock;
 
-    /**
-     * @var \Ibexa\Bundle\SystemInfo\SystemInfo\Collector\ServicesSystemInfoCollector
-     */
     private ServicesSystemInfoCollector $serviceCollector;
 
     protected function setUp(): void

--- a/tests/bundle/View/SystemInfoViewBuilderTest.php
+++ b/tests/bundle/View/SystemInfoViewBuilderTest.php
@@ -12,24 +12,16 @@ use Ibexa\Bundle\SystemInfo\SystemInfo\SystemInfoCollectorRegistry;
 use Ibexa\Bundle\SystemInfo\SystemInfo\Value\SystemInfo;
 use Ibexa\Bundle\SystemInfo\View\SystemInfoViewBuilder;
 use Ibexa\Core\MVC\Symfony\View\Configurator;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class SystemInfoViewBuilderTest extends TestCase
 {
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject&\Ibexa\Core\MVC\Symfony\View\Configurator
-     */
-    private Configurator $configuratorMock;
+    private Configurator&MockObject $configuratorMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject&\Ibexa\Bundle\SystemInfo\SystemInfo\SystemInfoCollectorRegistry
-     */
-    private SystemInfoCollectorRegistry $registryMock;
+    private SystemInfoCollectorRegistry&MockObject $registryMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject&\Ibexa\Bundle\SystemInfo\SystemInfo\Collector\SystemInfoCollector
-     */
-    private SystemInfoCollector $collectorMock;
+    private SystemInfoCollector&MockObject $collectorMock;
 
     public function testMatches(): void
     {
@@ -76,10 +68,7 @@ class SystemInfoViewBuilderTest extends TestCase
         return $this->configuratorMock;
     }
 
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject&\Ibexa\Bundle\SystemInfo\SystemInfo\SystemInfoCollectorRegistry
-     */
-    protected function getRegistryMock(): SystemInfoCollectorRegistry
+    protected function getRegistryMock(): SystemInfoCollectorRegistry&MockObject
     {
         $this->registryMock ??= $this->createMock(
             SystemInfoCollectorRegistry::class
@@ -88,10 +77,7 @@ class SystemInfoViewBuilderTest extends TestCase
         return $this->registryMock;
     }
 
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject&\Ibexa\Bundle\SystemInfo\SystemInfo\Collector\SystemInfoCollector
-     */
-    protected function getCollectorMock(): SystemInfoCollector
+    protected function getCollectorMock(): SystemInfoCollector&MockObject
     {
         $this->collectorMock ??= $this->createMock(SystemInfoCollector::class);
 

--- a/tests/lib/EventListener/SystemInfoTabGroupListenerTest.php
+++ b/tests/lib/EventListener/SystemInfoTabGroupListenerTest.php
@@ -20,14 +20,11 @@ use PHPUnit\Framework\TestCase;
 
 class SystemInfoTabGroupListenerTest extends TestCase
 {
-    /** @var \Ibexa\AdminUi\Tab\Event\TabGroupEvent */
     private TabGroupEvent $event;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\AdminUi\Tab\TabRegistry */
-    private MockObject $tabRegistry;
+    private TabRegistry&MockObject $tabRegistry;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\SystemInfo\Tab\SystemInfo\TabFactory */
-    private MockObject $tabFactory;
+    private TabFactory&MockObject $tabFactory;
 
     protected function setUp(): void
     {

--- a/tests/lib/EventListener/SystemInfoTabGroupListenerTest.php
+++ b/tests/lib/EventListener/SystemInfoTabGroupListenerTest.php
@@ -15,18 +15,19 @@ use Ibexa\Bundle\SystemInfo\SystemInfo\SystemInfoCollectorRegistry;
 use Ibexa\SystemInfo\EventListener\SystemInfoTabGroupListener;
 use Ibexa\SystemInfo\Tab\SystemInfo\SystemInfoTab;
 use Ibexa\SystemInfo\Tab\SystemInfo\TabFactory;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class SystemInfoTabGroupListenerTest extends TestCase
 {
     /** @var \Ibexa\AdminUi\Tab\Event\TabGroupEvent */
-    private $event;
+    private TabGroupEvent $event;
 
     /** @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\AdminUi\Tab\TabRegistry */
-    private $tabRegistry;
+    private MockObject $tabRegistry;
 
     /** @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\SystemInfo\Tab\SystemInfo\TabFactory */
-    private $tabFactory;
+    private MockObject $tabFactory;
 
     protected function setUp(): void
     {

--- a/tests/lib/VersionStability/VersionStabilityCheckerTest.php
+++ b/tests/lib/VersionStability/VersionStabilityCheckerTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 final class VersionStabilityCheckerTest extends TestCase
 {
     /** @var \Ibexa\SystemInfo\VersionStability\VersionStabilityChecker */
-    private $versionStabilityChecker;
+    private ComposerVersionStabilityChecker $versionStabilityChecker;
 
     public function setUp(): void
     {

--- a/tests/lib/VersionStability/VersionStabilityCheckerTest.php
+++ b/tests/lib/VersionStability/VersionStabilityCheckerTest.php
@@ -14,7 +14,6 @@ use PHPUnit\Framework\TestCase;
 
 final class VersionStabilityCheckerTest extends TestCase
 {
-    /** @var \Ibexa\SystemInfo\VersionStability\VersionStabilityChecker */
     private ComposerVersionStabilityChecker $versionStabilityChecker;
 
     public function setUp(): void


### PR DESCRIPTION
> [!CAUTION]
> These changes are volatile and - in some repositories - extensive, so they need to be carefully reviewed before merging.

| :ticket: Issue | IBX-9727 |
|----------------|-----------|

#### Description:

Added missing strict type hints using `\Rector\Set\ValueObject\SetList::TYPE_DECLARATION` set.
Additionally FQCNs have been imported for every affected file using PHP CS Fixer, in some cases they might override unrelated lines.

PHPStan bump is required due to requirements of Ibexa Rector and Rector itself.

#### For QA:

Regression tests.
