### PR TITLE
Deprecated unused EzInfoTwigComponent

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   cs-fix:
     name: Run code style check
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     strategy:
       matrix:
         php:
@@ -35,7 +35,7 @@ jobs:
 
   tests:
     name: Tests
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     timeout-minutes: 10
 
     strategy:
@@ -75,7 +75,7 @@ jobs:
   integration-tests:
     name: Integration yests
     needs: tests
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     timeout-minutes: 10
 
     strategy:

--- a/src/lib/Component/Dashboard/EzInfoTwigComponent.php
+++ b/src/lib/Component/Dashboard/EzInfoTwigComponent.php
@@ -12,6 +12,9 @@ use Ibexa\Bundle\SystemInfo\SystemInfo\Value\IbexaSystemInfo;
 use Ibexa\Contracts\AdminUi\Component\Renderable;
 use Twig\Environment;
 
+/**
+ * @deprecated Since ibexa/system-info 4.6: The "EzInfoTwigComponent" class is deprecated, will be removed in 5.0.
+ */
 class EzInfoTwigComponent implements Renderable
 {
     protected string $template;


### PR DESCRIPTION
Service definition was dropped in 
https://github.com/ibexa/system-info/commit/d05bb33deb2fc4d17646b2ee31587637f9bb8d67
during redesign. It seems safe to drop class instead of renaming it or bring it back in anyway.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
