### PR TITLE
Replaced deprecated DBAL count expression

### DIFF
--- a/src/lib/Storage/Metrics/ContentTypesCountMetrics.php
+++ b/src/lib/Storage/Metrics/ContentTypesCountMetrics.php
@@ -16,9 +16,9 @@ use Ibexa\Core\Persistence\Legacy\Content\Type\Gateway as ContentTypeGateway;
  */
 final class ContentTypesCountMetrics extends RepositoryConnectionAwareMetrics
 {
-    private const CONTENT_TYPE_TABLE = ContentTypeGateway::CONTENT_TYPE_TABLE;
-    private const ID_COLUMN = 'id';
-    private const VERSION_COLUMN = 'version';
+    private const string CONTENT_TYPE_TABLE = ContentTypeGateway::CONTENT_TYPE_TABLE;
+    private const string ID_COLUMN = 'id';
+    private const string VERSION_COLUMN = 'version';
 
     /**
      * @throws \Doctrine\DBAL\Exception

--- a/src/lib/Storage/Metrics/DraftsCountMetrics.php
+++ b/src/lib/Storage/Metrics/DraftsCountMetrics.php
@@ -17,8 +17,8 @@ use Ibexa\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
  */
 final class DraftsCountMetrics extends RepositoryConnectionAwareMetrics
 {
-    private const CONTENTOBJECT_VERSION_TABLE = ContentGateway::CONTENT_VERSION_TABLE;
-    private const CONTENTOBJECT_TABLE = ContentGateway::CONTENT_ITEM_TABLE;
+    private const string CONTENTOBJECT_VERSION_TABLE = ContentGateway::CONTENT_VERSION_TABLE;
+    private const string CONTENTOBJECT_TABLE = ContentGateway::CONTENT_ITEM_TABLE;
 
     /**
      * @throws \Doctrine\DBAL\Exception

--- a/src/lib/Storage/Metrics/PublishedContentObjectsCountMetrics.php
+++ b/src/lib/Storage/Metrics/PublishedContentObjectsCountMetrics.php
@@ -16,9 +16,9 @@ use Ibexa\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
  */
 final class PublishedContentObjectsCountMetrics extends RepositoryConnectionAwareMetrics
 {
-    private const CONTENTOBJECT_TABLE = ContentGateway::CONTENT_ITEM_TABLE;
-    private const ID_COLUMN = 'id';
-    private const STATUS_COLUMN = 'status';
+    private const string CONTENTOBJECT_TABLE = ContentGateway::CONTENT_ITEM_TABLE;
+    private const string ID_COLUMN = 'id';
+    private const string STATUS_COLUMN = 'status';
 
     /**
      * @throws \Doctrine\DBAL\Exception

--- a/src/lib/Storage/Metrics/RepositoryConnectionAwareMetrics.php
+++ b/src/lib/Storage/Metrics/RepositoryConnectionAwareMetrics.php
@@ -16,20 +16,14 @@ use Ibexa\SystemInfo\Storage\Metrics;
  */
 abstract class RepositoryConnectionAwareMetrics implements Metrics
 {
-    protected Connection $connection;
-
     abstract public function getValue(): int;
 
-    public function __construct(Connection $connection)
+    public function __construct(protected Connection $connection)
     {
-        $this->connection = $connection;
     }
 
-    /**
-     * @throws \Doctrine\DBAL\Exception
-     */
     protected function getCountExpression(string $columnName): string
     {
-        return $this->connection->getDatabasePlatform()->getCountExpression($columnName);
+        return 'COUNT(' . $this->connection->quoteIdentifier($columnName) . ')';
     }
 }

--- a/src/lib/Storage/Metrics/UsersCountMetrics.php
+++ b/src/lib/Storage/Metrics/UsersCountMetrics.php
@@ -15,8 +15,8 @@ use Ibexa\Core\Persistence\Legacy\User\Gateway as UserGateway;
  */
 final class UsersCountMetrics extends RepositoryConnectionAwareMetrics
 {
-    private const USER_TABLE = UserGateway::USER_TABLE;
-    private const CONTENTOBJECT_ID_COLUMN = 'contentobject_id';
+    private const string USER_TABLE = UserGateway::USER_TABLE;
+    private const string CONTENTOBJECT_ID_COLUMN = 'contentobject_id';
 
     /**
      * @throws \Doctrine\DBAL\Exception

--- a/src/lib/Storage/Metrics/VersionsCountMetrics.php
+++ b/src/lib/Storage/Metrics/VersionsCountMetrics.php
@@ -15,8 +15,8 @@ use Ibexa\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
  */
 final class VersionsCountMetrics extends RepositoryConnectionAwareMetrics
 {
-    private const CONTENTOBJECT_VERSION_TABLE = ContentGateway::CONTENT_VERSION_TABLE;
-    private const ID_COLUMN = 'id';
+    private const string CONTENTOBJECT_VERSION_TABLE = ContentGateway::CONTENT_VERSION_TABLE;
+    private const string ID_COLUMN = 'id';
 
     /**
      * @throws \Doctrine\DBAL\Exception


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|

#### Description:
Replaces deprecated Doctrine DBAL Platform::getCountExpression() usage with an explicit COUNT expression in SystemInfo.

No functional changes introduced

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
