### PR TITLE
Fixed dev-stability resolution for ibexa/design-system-twig

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "ibexa/code-style": "~2.0.0",
         "ibexa/content-forms": "~6.0.x-dev",
         "ibexa/design-engine": "~6.0.x-dev",
+        "ibexa/design-system-twig": "~6.0.x-dev",
         "ibexa/doctrine-schema": "~6.0.x-dev",
         "ibexa/fieldtype-richtext": "~6.0.x-dev",
         "ibexa/http-cache": "~6.0.x-dev",


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!--
#### Related PRs:
- https://github.com/ibexa/installer/pull/215
-->

#### Description:
`ibexa/admin-ui` (required directly in `require`) transitively requires `ibexa/design-system-twig ~6.0.x-dev`, a dev-only package with no stable release yet.

This repo has no `minimum-stability`/`prefer-stable` setting (defaults to `stable`), so resolving `composer.json` directly in this repo fails with a "does not match your minimum-stability" error.

Composer only enforces `minimum-stability` against transitive dependencies, not explicit direct root requirements for a dev branch — so adding it directly to `require-dev` at `~6.0.x-dev` (same convention as every other entry in this file, and matching the equivalent fix in ibexa/installer#215) is enough on its own.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->